### PR TITLE
Make it impossible to create a participant that is dead

### DIFF
--- a/Valghalla.External.API/Controllers/Tasks/TaskCommandController.cs
+++ b/Valghalla.External.API/Controllers/Tasks/TaskCommandController.cs
@@ -18,9 +18,9 @@ namespace Valghalla.External.API.Controllers.Tasks
         }
 
         [HttpPost("accepttask")]
-        public async Task<IActionResult> AcceptTaskAsync(string hashValue, Guid? code, CancellationToken cancellationToken)
+        public async Task<IActionResult> AcceptTaskAsync(string hashValue, Guid? code, bool taskInvitation, CancellationToken cancellationToken)
         {
-            var query = new AcceptTaskCommand(hashValue, code);
+            var query = new AcceptTaskCommand(hashValue, code, taskInvitation);
             var response = await sender.Send(query, cancellationToken);
             return Ok(response);
         }
@@ -34,9 +34,9 @@ namespace Valghalla.External.API.Controllers.Tasks
         }
 
         [HttpPost("unregistertask")]
-        public async Task<IActionResult> UnregisterTaskAsync(Guid taskAssignmentId, CancellationToken cancellationToken)
+        public async Task<IActionResult> UnregisterTaskAsync(Guid taskAssignmentId,string hashValue, CancellationToken cancellationToken)
         {
-            var query = new UnregisterTaskCommand(taskAssignmentId);
+            var query = new UnregisterTaskCommand(taskAssignmentId,hashValue);
             var response = await sender.Send(query, cancellationToken);
             return Ok(response);
         }

--- a/Valghalla.External.Application/Modules/Tasks/Commands/RejectTaskCommand.cs
+++ b/Valghalla.External.Application/Modules/Tasks/Commands/RejectTaskCommand.cs
@@ -40,7 +40,7 @@ namespace Valghalla.External.Application.Modules.Tasks.Commands
         public async Task<Response> Handle(RejectTaskCommand command, CancellationToken cancellationToken)
         {
             var participantId = userContextProvider.CurrentUser.ParticipantId!.Value;
-            var taskAssignment = await taskQueryRepository.GetTaskAssignmentAsync(command.HashValue, command.InvitationCode, participantId, cancellationToken);
+            var taskAssignment = await taskQueryRepository.GetTaskAssignmentAsync(command.HashValue, command.InvitationCode,false, participantId, cancellationToken);
 
             if (taskAssignment == null)
             {

--- a/Valghalla.External.Application/Modules/Tasks/Commands/UnregisterTaskCommand.cs
+++ b/Valghalla.External.Application/Modules/Tasks/Commands/UnregisterTaskCommand.cs
@@ -1,13 +1,14 @@
 ﻿using FluentValidation;
+
 using Valghalla.Application.Abstractions.Messaging;
+using Valghalla.Application.Communication;
 using Valghalla.Application.User;
 using Valghalla.External.Application.Modules.Tasks.Interfaces;
 using Valghalla.External.Application.Modules.Tasks.Responses;
 
 namespace Valghalla.External.Application.Modules.Tasks.Commands
 {
-    public sealed record UnregisterTaskCommand(Guid TaskAssignmentId) : ICommand<Response>;
-
+    public sealed record UnregisterTaskCommand(Guid TaskAssignmentId, string HashValue) : ICommand<Response>;
     public sealed class UnregisterTaskCommandValidator : AbstractValidator<UnregisterTaskCommand>
     {
         public UnregisterTaskCommandValidator()
@@ -21,20 +22,33 @@ namespace Valghalla.External.Application.Modules.Tasks.Commands
     {
         private readonly IUserContextProvider userContextProvider;
         private readonly ITaskCommandRepository taskCommandRepository;
+        private readonly ITaskQueryRepository taskQueryRepository;
+        private readonly ICommunicationService communicationService;
 
         public UnregisterTaskCommandHandler(
             IUserContextProvider userContextProvider,
-            ITaskCommandRepository taskCommandRepository)
+            ITaskCommandRepository taskCommandRepository,
+            ICommunicationService communicationService,
+            ITaskQueryRepository taskQueryRepository)
         {
             this.userContextProvider = userContextProvider;
             this.taskCommandRepository = taskCommandRepository;
+            this.communicationService = communicationService;
+            this.taskQueryRepository = taskQueryRepository;
         }
 
         public async Task<Response> Handle(UnregisterTaskCommand command, CancellationToken cancellationToken)
         {
             var participantId = userContextProvider.CurrentUser.ParticipantId!.Value;
+            var taskAssignment = await taskQueryRepository.GetTaskAssignmentAsync(command.HashValue, participantId, cancellationToken);
 
+            if (taskAssignment == null)
+            {
+                return Response.Ok(TaskConfirmationResult.CprInvalidResult());
+            }
             await taskCommandRepository.UnregisterTaskAsync(command, participantId, cancellationToken);
+
+            await communicationService.SendTaskCancellationAsync(participantId, taskAssignment.Id, cancellationToken);
 
             return Response.Ok(TaskConfirmationResult.SuccessResult());
         }

--- a/Valghalla.External.Application/Modules/Tasks/Interfaces/ITaskQueryRepository.cs
+++ b/Valghalla.External.Application/Modules/Tasks/Interfaces/ITaskQueryRepository.cs
@@ -13,7 +13,8 @@ namespace Valghalla.External.Application.Modules.Tasks.Interfaces
         Task<IList<TaskDetailsResponse>> GetMyTasksAsync(Guid participantId, CancellationToken cancellationToken);
         Task<TeamResponsibleTasksFiltersOptionsResponse> GetTeamResponsibleTasksFiltersOptionsAsync(Guid teamResponsibleId, CancellationToken cancellationToken);
         Task<TeamResponsibleTaskResponse> GetTeamResponsibleTasksAsync(Guid teamResponsibleId, GetTeamResponsibleTasksQuery query, CancellationToken cancellationToken);
-        Task<TaskAssignmentResponse?> GetTaskAssignmentAsync(string hashValue, Guid? invitationCode, Guid participantId, CancellationToken cancellationToken);
+        Task<TaskAssignmentResponse?> GetTaskAssignmentAsync(string hashValue, Guid? invitationCode,bool taskInvitation, Guid participantId, CancellationToken cancellationToken);
+        Task<TaskAssignmentResponse?> GetTaskAssignmentAsync(string hashValue, Guid participantId, CancellationToken cancellationToken);
         Task<bool> CheckIfTaskHasConflicts(Guid participantId, DateTime taskDate, TimeSpan startTime, TimeSpan endTime, Guid? invitationCode, CancellationToken cancellationToken);
     }
 }

--- a/Valghalla.External.Infrastructure/Modules/Tasks/TaskCommandRepository.cs
+++ b/Valghalla.External.Infrastructure/Modules/Tasks/TaskCommandRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+
 using Valghalla.Database;
 using Valghalla.Database.Entities.Tables;
 using Valghalla.External.Application.Modules.Tasks.Commands;
@@ -33,9 +34,13 @@ namespace Valghalla.External.Infrastructure.Modules.Tasks
                     i.ParticipantId == participantId &&
                     i.InvitationCode == command.InvitationCode);
             }
-            else
+            else if (!command.taskInvitation)
             {
                 queryable = queryable.Where(i => i.ParticipantId == null);
+            }
+            else
+            {
+                queryable = queryable.Where(i => i.ParticipantId == participantId);
             }
 
             var entity = await queryable.FirstAsync(cancellationToken);
@@ -57,8 +62,8 @@ namespace Valghalla.External.Infrastructure.Modules.Tasks
             var queryable = taskAssignments
                 .Include(i => i.TaskType)
                 .Where(i =>
-                    i.HashValue == command.HashValue &&
-                    i.Responsed == false);
+                    i.HashValue == command.HashValue
+                    );
 
             if (command.InvitationCode.HasValue)
             {

--- a/Valghalla.External.Web/src/assets/i18n/da.json
+++ b/Valghalla.External.Web/src/assets/i18n/da.json
@@ -151,6 +151,8 @@
       "more_info": "Mere info",
       "register": "Tilmeld",
       "unregister": "Afmeld",
+      "accept_task": "Accepter opgave",
+      "reject_task": "Afvis opgave",
       "view_more_filters": "Vis flere filtre",
       "view_less_filters": "Se færre filtre",
       "register_confirmation_text": "Vil du tilmelde dig denne opgave den",
@@ -166,7 +168,7 @@
       "labels": {
         "task_description": "Opgavebeskrivelse",
         "you_are_registered": "Du er tilmeldt",
-        "you_are_invited": "Du er inviteret",
+        "you_are_invited": "Du er inviteret, venligst svar",
         "unregister_from": "Afmeld fra",
         "unregister_dialog_content": "Du vil blive afmeldt fra opgaven og vil ikke modtage betaling. Det bliver muligt for andre at tilmelde sig opgaven. Når du bekræfter, kan du ikke længere fortryde det",
         "task_locked_warning": "Det er ikke muligt at afmelde sig fra denne opgave, da den finder sted snart. <a href='/kontakt-os'>Kontakt os</a> venligst, hvis du ikke har mulighed for at deltage"
@@ -197,7 +199,8 @@
     "task_details": {
       "page_title": "Opgavedetaljer",
       "login_register": "Log ind og tilmeld",
-      "register": "Tilmeld",
+      "register": "Accepter og tilmeld dig",
+      "reject_task": "Afvis opgave",
       "copy_link_to_task": "Kopier link til opgave",
       "link": "Link",
       "register_yourself": "Tilmeld dig selv",

--- a/Valghalla.External.Web/src/assets/i18n/en.json
+++ b/Valghalla.External.Web/src/assets/i18n/en.json
@@ -151,6 +151,8 @@
       "more_info": "More info",
       "register": "Register",
       "unregister": "Unregister",
+      "accept_task": "Accept task",
+      "reject_task": "Reject task",
       "view_more_filters": "View more filters",
       "view_less_filters": "View less filters",
       "register_confirmation_text": "Do you want to register for this task on",
@@ -166,7 +168,7 @@
       "labels": {
         "task_description": "Task description",
         "you_are_registered": "You are registered",
-        "you_are_invited": "You are invited",
+        "you_are_invited": "You are invited, please respond",
         "unregister_from": "Unregister from",
         "unregister_dialog_content": "You will be unregistered from the task and will not receive payment. The task becomes possible for others to register. Once you confirm, you can no longer undo it.",
         "task_locked_warning": "It is not possible to unregister from this task, because it takes place soon. Please <a href='/contact-us'>contact us</a>, if you do not have the opportunity to participate."
@@ -197,7 +199,8 @@
     "task_details": {
       "page_title": "Task details",
       "login_register": "Log in and register",
-      "register": "Register",
+      "register": "Accept and register",
+      "reject_task": "Reject task",
       "copy_link_to_task": "Copy link to task",
       "link": "Link",
       "register_yourself": "Register yourself",

--- a/Valghalla.External.Web/src/features/my-tasks/components/landing.component.html
+++ b/Valghalla.External.Web/src/features/my-tasks/components/landing.component.html
@@ -1,86 +1,107 @@
 <div class="d-flex flex-row justify-content-between">
-    <h1>{{ 'tasks.my_tasks.header' | transloco }}</h1>
-    <a href="javascript:if(window.print)window.print()" class="function-link">
-        <svg class="icon-svg" focusable="false" aria-hidden="true"><use xlink:href="#print"></use></svg>
-        {{ 'shared.common.print' | transloco }}
-    </a>
+  <h1>{{ 'tasks.my_tasks.header' | transloco }}</h1>
+  <a href="javascript:if(window.print)window.print()" class="function-link">
+    <svg class="icon-svg" focusable="false" aria-hidden="true"><use xlink:href="#print"></use></svg>
+    {{ 'shared.common.print' | transloco }}
+  </a>
 </div>
 <ng-container *appSpinner="loading">
-    <ng-container *ngFor="let task of tasks; let i = index">
+  <ng-container *ngFor="let task of tasks; let i = index">
         <h2 *ngIf="(i == 0 || tasks[i - 1].taskDate != task.taskDate)">{{ getTaskDateFriendlyText(task.taskDate) }} </h2>
-        <div class="d-flex flex-row justify-content-between align-items-center">
-            <div>
-                <h3>{{ task.taskType.title }}</h3>
-                <div class="alert alert-warning alert--show-icon" *ngIf="task.isLocked" role="alert">
-                    <div class="alert-body">
+    <div class="d-flex flex-row justify-content-between align-items-center">
+      <div>
+        <h3>{{ task.taskType.title }}</h3>
+        <div class="alert alert-warning alert--show-icon" *ngIf="task.isLocked" role="alert">
+          <div class="alert-body">
                         <h4 class="alert-heading" [innerHTML]="('tasks.my_tasks.labels.task_locked_warning' | transloco)"></h4>
-                    </div>
-                </div>
-            </div>
-            <button class="button button-primary d-print-none d-none d-md-block" *ngIf="!task.isLocked" data-module="modal" [attr.data-target]="'modal-unregister-' + task.taskAssignmentId" aria-haspopup="dialog">
-                <svg class="icon-svg" focusable="false" aria-hidden="true"><use xlink:href="#trash-can"></use></svg>
-                {{ 'tasks.labels.unregister' | transloco }}
-            </button>
-            <div
-                appModal
-                class="fds-modal"
-                [attr.id]="'modal-unregister-' + task.taskAssignmentId" 
-                aria-hidden="true"
-                role="dialog"
-                aria-modal="true"
-                [attr.aria-labelledby]="task.taskAssignmentId">
-                <div class="modal-content">
-                    <div class="modal-header">
+          </div>
+        </div>
+      </div>
+      <div class="d-flex flex-row">
+        <button
+          class="button button-primary d-print-none d-none d-md-block"
+          *ngIf="!task.accepted"
+          (click)="acceptTask(task.hashValue)"
+          [disabled]="task.isLocked">
+          {{ 'tasks.labels.accept_task' | transloco }}
+        </button>
+        <button
+          class="button button-secondary d-print-none d-none d-md-block"
+          *ngIf="!task.accepted"
+          (click)="unregisterTask(task.taskAssignmentId, task.hashValue)"
+          [disabled]="task.isLocked">
+          {{ 'tasks.labels.reject_task' | transloco }}
+        </button>
+        <button
+          class="button button-primary d-print-none d-none d-md-block"
+          *ngIf="!task.isLocked && task.accepted"
+          data-module="modal"
+          [attr.data-target]="'modal-unregister-' + task.taskAssignmentId"
+          aria-haspopup="dialog">
+          <svg class="icon-svg" focusable="false" aria-hidden="true"><use xlink:href="#trash-can"></use></svg>
+          {{ 'tasks.labels.unregister' | transloco }}
+        </button>
+      </div>
+      <div
+        appModal
+        class="fds-modal"
+        [attr.id]="'modal-unregister-' + task.taskAssignmentId"
+        aria-hidden="true"
+        role="dialog"
+        aria-modal="true"
+        [attr.aria-labelledby]="task.taskAssignmentId">
+        <div class="modal-content">
+          <div class="modal-header">
                     <h2 class="modal-title" [attr.id]="task.taskAssignmentId">{{ 'tasks.my_tasks.labels.unregister_from' | transloco}} {{ task.taskType.title }}</h2>
-                    <button class="modal-close function-link" data-modal-close>
+            <button class="modal-close function-link" data-modal-close>
                         <svg class="icon-svg" focusable="false" aria-hidden="true"><use xlink:href="#close"></use></svg>{{ 'shared.common.close' | transloco}}
-                    </button>
-                    </div>
-                    <div class="modal-body">
-                        <p>
+            </button>
+          </div>
+          <div class="modal-body">
+            <p>
                             {{ 'tasks.my_tasks.labels.unregister_dialog_content' | transloco}}
-                        </p>
-                    </div>
-                    <div class="modal-footer">
-                        <button class="button button-primary" (click)="unregisterTask(task.taskAssignmentId)" data-modal-close>{{ 'tasks.labels.unregister' | transloco}}</button>
+            </p>
+          </div>
+          <div class="modal-footer">
+                        <button class="button button-primary" (click)="unregisterTask(task.taskAssignmentId,task.hashValue)" data-modal-close>{{ 'tasks.labels.unregister' | transloco}}</button>
                         <button class="button button-secondary" data-modal-close>{{ 'shared.common.cancel' | transloco}}</button>
-                    </div>
-                </div>
-            </div>
-        </div>        
-        <div class="mb-4">
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="mb-4">
             <span class="badge badge-small badge-success" *ngIf="task.accepted">{{ 'tasks.my_tasks.labels.you_are_registered' | transloco }}</span>
             <span class="badge badge-small badge-warning" *ngIf="!task.accepted">{{ 'tasks.my_tasks.labels.you_are_invited' | transloco }}</span>            
-        </div>
-        <div class="mb-4 d-print-none d-block d-md-none d-lg-none d-xl-none">
+    </div>
+    <div class="mb-4 d-print-none d-block d-md-none d-lg-none d-xl-none">
             <button class="button button-primary" *ngIf="!task.isLocked" data-module="modal" [attr.data-target]="'modal-unregister-' + task.taskAssignmentId" aria-haspopup="dialog">
-                <svg class="icon-svg" focusable="false" aria-hidden="true"><use xlink:href="#trash-can"></use></svg>
-                {{ 'tasks.labels.unregister' | transloco }}
-            </button>
-        </div>
-        <app-task-preview [model]="task"></app-task-preview>
+        <svg class="icon-svg" focusable="false" aria-hidden="true"><use xlink:href="#trash-can"></use></svg>
+        {{ 'tasks.labels.unregister' | transloco }}
+      </button>
+    </div>
+    <app-task-preview [model]="task"></app-task-preview>
         <div class="w-percent-80 py-2 files" *ngIf="task.taskType && task.taskType.fileReferences && task.taskType.fileReferences.length > 0">
-            <div class="row row-bordered no-gutters">
-                <div class="col">
-                <span class="bold">{{ 'tasks.task_preview.labels.files' | transloco }}</span>
-                </div>
-                <div class="col">
-                    <ul class="mt-0">
-                        <li class="mb-2" *ngFor="let file of task.taskType.fileReferences">
-                            <a href="#" class="function-link" [href]="getFileDownloadLink(file)" download>{{file.fileName}}</a>
-                        </li>
-                    </ul>
-                </div>
-            </div>
+      <div class="row row-bordered no-gutters">
+        <div class="col">
+          <span class="bold">{{ 'tasks.task_preview.labels.files' | transloco }}</span>
         </div>
-        <details class="details pt-4 d-print-none">
-            <summary class="details-summary">
-                {{ 'tasks.my_tasks.labels.task_description' | transloco }}
-            </summary>
+        <div class="col">
+          <ul class="mt-0">
+            <li class="mb-2" *ngFor="let file of task.taskType.fileReferences">
+                            <a href="#" class="function-link" [href]="getFileDownloadLink(file)" download>{{file.fileName}}</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <details class="details pt-4 d-print-none">
+      <summary class="details-summary">
+        {{ 'tasks.my_tasks.labels.task_description' | transloco }}
+      </summary>
             <div class="details-text" [innerHTML]="task.taskType.description">
             </div>
-        </details>
+    </details>
         <div class="d-none d-print-block" [innerHTML]="task.taskType.description">
         </div>        
-    </ng-container>
+  </ng-container>
 </ng-container>

--- a/Valghalla.External.Web/src/features/my-tasks/components/landing.component.ts
+++ b/Valghalla.External.Web/src/features/my-tasks/components/landing.component.ts
@@ -15,38 +15,38 @@ import { GlobalStateService } from 'src/app/global-state.service';
   styleUrls: ['./landing.component.scss'],
   providers: [AppWeekdayNamePipe, AppMonthNamePipe, TaskHttpService],
 })
-export class MyTasksLandingComponent implements AfterViewInit{
+export class MyTasksLandingComponent implements AfterViewInit {
   private readonly subs = new SubSink();
 
   loading = true;
 
   tasks: Array<TaskDetails> = [];
-  
+
   constructor(
     private readonly globalStateService: GlobalStateService,
     private readonly appWeekdayNamePipe: AppWeekdayNamePipe,
     private readonly appMonthNamePipe: AppMonthNamePipe,
     private readonly translocoService: TranslocoService,
     private readonly taskHttpService: TaskHttpService,
-  ) {}
+  ) { }
 
-  ngAfterViewInit () {
+  ngAfterViewInit() {
     this.subs.sink = this.taskHttpService
-    .getMyTasks()
-    .pipe(
-      finalize(() => {
-        this.loading = false;
-      }),
-    )
-    .subscribe((res) => {
-      if (res.isSuccess) {
-        this.tasks = res.data;
-      }
-    });
+      .getMyTasks()
+      .pipe(
+        finalize(() => {
+          this.loading = false;
+        }),
+      )
+      .subscribe((res) => {
+        if (res.isSuccess) {
+          this.tasks = res.data;
+        }
+      });
   }
 
-  unregisterTask(taskAssignmentId) {
-    this.taskHttpService.unregisterTask(taskAssignmentId).subscribe((res) => {
+  unregisterTask(taskAssignmentId, hashValue) {
+    this.taskHttpService.unregisterTask(taskAssignmentId, hashValue).subscribe((res) => {
       if (res.isSuccess && res.data.succeed) {
         var deletedTask = this.tasks.filter(f => f.taskAssignmentId == taskAssignmentId)[0];
         this.tasks.splice(this.tasks.indexOf(deletedTask), 1);
@@ -54,7 +54,7 @@ export class MyTasksLandingComponent implements AfterViewInit{
         this.globalStateService.userTeamFetching.next();
       }
     });
-  } 
+  }
 
   getTaskDateFriendlyText(taskDate) {
     var date = new Date(taskDate);
@@ -63,5 +63,13 @@ export class MyTasksLandingComponent implements AfterViewInit{
 
   getFileDownloadLink(file: FileReference) {
     return this.taskHttpService.getDownloadFileLink(file.id);
+  }
+
+  acceptTask(hashValue,) {
+    this.taskHttpService.acceptTask(hashValue, '',true, false).subscribe((res) => {
+      if (res.isSuccess && res.data.succeed) {
+        this.globalStateService.userTeamFetching.next();
+      }
+    });
   }
 }

--- a/Valghalla.External.Web/src/features/registration/components/my-profile-registration-confirmator/my-profile-registration-confirmator.component.ts
+++ b/Valghalla.External.Web/src/features/registration/components/my-profile-registration-confirmator/my-profile-registration-confirmator.component.ts
@@ -70,7 +70,7 @@ export class MyProfileRegistrationConfirmatorComponent implements OnInit, OnDest
     } else if (this.type == 'task') {
       this.saving = true;
       this.subs.sink = this.taskHttpService
-        .acceptTask(this.hashValue, this.invitationCode, true)
+        .acceptTask(this.hashValue, this.invitationCode,false, true)
         .pipe(
           finalize(() => {
             this.saving = false;

--- a/Valghalla.External.Web/src/features/registration/task-registration.guard.ts
+++ b/Valghalla.External.Web/src/features/registration/task-registration.guard.ts
@@ -67,7 +67,7 @@ export class TaskRegistrationGuard  {
 
         if (authorized) {
           this.taskHttpService
-            .acceptTask(hashValue, invitationCode, false)
+            .acceptTask(hashValue, invitationCode,false, false)
             .pipe(
               take(1),
               catchError((err) => {

--- a/Valghalla.External.Web/src/features/tasks/components/task-details/task-details.component.html
+++ b/Valghalla.External.Web/src/features/tasks/components/task-details/task-details.component.html
@@ -20,6 +20,9 @@
     <button class="button button-primary d-print-none" (click)="register()">
       {{ signedIn ? ('tasks.task_details.register' | transloco) : ('tasks.task_details.login_register' | transloco) }}
     </button>
+    <button class="button button-secondary d-print-none" (click)="rejectTask()" *ngIf="signedIn">
+      {{ 'tasks.task_details.reject_task' | transloco }}
+    </button>
     <div class="w-percent-100 w-percent-md-70 py-4">
       <app-task-preview [model]="taskPreview"></app-task-preview>
       <div class="py-2" [innerHTML]="taskPreview.taskType.description"></div>

--- a/Valghalla.External.Web/src/features/tasks/components/task-details/task-details.component.ts
+++ b/Valghalla.External.Web/src/features/tasks/components/task-details/task-details.component.ts
@@ -26,7 +26,7 @@ export class TaskDetailsComponent {
     private readonly route: ActivatedRoute,
     private readonly authService: AuthService,
     private readonly taskHttpService: TaskHttpService,
-  ) {}
+  ) { }
 
   ngOnInit(): void {
     this.hashValue = this.route.snapshot.paramMap.get(RoutingNodes.Id);
@@ -57,5 +57,13 @@ export class TaskDetailsComponent {
 
   register() {
     this.router.navigate([RoutingNodes.Registration, RoutingNodes.TaskRegistration, this.hashValue]);
+  }
+  rejectTask() {
+    this.taskHttpService.rejectTask(this.hashValue).subscribe((res) => {
+      if (res.isSuccess && res.data.succeed) {
+        this.router.navigate([RoutingNodes.MyTasks]);
+      }
+    }
+    );
   }
 }

--- a/Valghalla.External.Web/src/features/tasks/services/task-http.service.ts
+++ b/Valghalla.External.Web/src/features/tasks/services/task-http.service.ts
@@ -28,7 +28,7 @@ export class TaskHttpService {
     private readonly httpClient: HttpClient,
     private readonly translocoService: TranslocoService,
     private readonly notificationService: NotificationService,
-  ) {}
+  ) { }
 
   getTaskPreview(hashValue: string, invitationCode?: string): Observable<Response<TaskPreview>> {
     let query = {
@@ -76,6 +76,7 @@ export class TaskHttpService {
   acceptTask(
     hashValue: string,
     invitationCode?: string,
+    taskInvitation?: boolean,
     showStepIndicator?: boolean,
   ): Observable<Response<TaskConfirmationResult>> {
     let query = {
@@ -87,6 +88,14 @@ export class TaskHttpService {
         ...query,
         ...{
           code: invitationCode,
+        },
+      };
+    }
+    if (taskInvitation) {
+      query = {
+        ...query,
+        ...{
+          taskInvitation: taskInvitation,
         },
       };
     }
@@ -193,11 +202,12 @@ export class TaskHttpService {
       );
   }
 
-  unregisterTask(taskAssignmentId: string): Observable<Response<TaskConfirmationResult>> {
+  unregisterTask(taskAssignmentId: string, hashValue: string): Observable<Response<TaskConfirmationResult>> {
     return this.httpClient
       .post<Response<TaskConfirmationResult>>(this.baseUrl + 'unregistertask', undefined, {
         params: {
           taskAssignmentId: taskAssignmentId,
+          hashValue: hashValue,
         },
       })
       .pipe(

--- a/Valghalla.Infrastructure/Communication/CommunicationQueryRepository.cs
+++ b/Valghalla.Infrastructure/Communication/CommunicationQueryRepository.cs
@@ -1,5 +1,7 @@
 ﻿using AutoMapper;
+
 using Microsoft.EntityFrameworkCore;
+
 using Valghalla.Application.Communication;
 using Valghalla.Database;
 using Valghalla.Database.Entities.Tables;
@@ -77,7 +79,7 @@ namespace Valghalla.Infrastructure.Communication
                 WorkLocation = new CommunicationWorkLocationInfo()
                 {
                     Title = entity.WorkLocation.Title,
-                    Address = entity.WorkLocation.Address,
+                    Address = $"{entity.WorkLocation.Address}, {entity.WorkLocation.PostalCode} {entity.WorkLocation.City}",
                 },
                 TaskType = new CommunicationTaskTypeInfo()
                 {

--- a/Valghalla.Internal.Web/src/features/participant/services/participant-http.service.ts
+++ b/Valghalla.Internal.Web/src/features/participant/services/participant-http.service.ts
@@ -21,7 +21,7 @@ export class ParticipantHttpService {
     private readonly httpClient: HttpClient,
     private readonly translocoService: TranslocoService,
     private readonly notificationService: NotificationService,
-  ) {}
+  ) { }
 
   getParticipantDetails(id: string): Observable<Response<ParticipantDetails>> {
     return this.httpClient
@@ -41,6 +41,7 @@ export class ParticipantHttpService {
   }
 
   getParticipantPersonalRecord(cpr: string): Observable<Response<ParticipantPersonalRecord>> {
+
     return this.httpClient
       .get<Response<ParticipantPersonalRecord>>(this.baseUrl + 'getparticipantpersonalrecord', {
         params: {
@@ -48,6 +49,16 @@ export class ParticipantHttpService {
         },
       })
       .pipe(
+        tap((res) => {
+          if (res.isSuccess && res.data.deceased) {
+            const msg = this.translocoService.translate('participant.error.participant_is_deceased');
+            this.notificationService.showError(msg);
+
+            return throwError(() => msg);
+          } else {
+            return res;
+          }
+        }),
         catchError((err) => {
           const msg = this.translocoService.translate('participant.error.get_participant_personal_record');
           this.notificationService.showError(msg);


### PR DESCRIPTION
When you create a participant on and put in the CPR-number of a dead person, an error should be shown when clicking the Check-button: