### PR TITLE
Move all vacant tasks from one team to another

### DIFF
--- a/Valghalla.Internal.API/Controllers/Tasks/WorkLocationTasksCommandController.cs
+++ b/Valghalla.Internal.API/Controllers/Tasks/WorkLocationTasksCommandController.cs
@@ -1,5 +1,7 @@
 ﻿using MediatR;
+
 using Microsoft.AspNetCore.Mvc;
+
 using Valghalla.Integration.Auth;
 using Valghalla.Internal.Application.Modules.Tasks.Commands;
 using Valghalla.Internal.Application.Modules.Tasks.Requests;
@@ -9,7 +11,7 @@ namespace Valghalla.Internal.API.Controllers.Tasks
     [ApiController]
     [Route("api/worklocationtasks")]
     [UserAuthorize(RoleEnum.Administrator)]
-    public class WorkLocationTasksCommandController: ControllerBase
+    public class WorkLocationTasksCommandController : ControllerBase
     {
         private readonly ISender sender;
 
@@ -73,6 +75,18 @@ namespace Valghalla.Internal.API.Controllers.Tasks
                 SpecialDietIds = request.SpecialDietIds,
             };
 
+            var result = await sender.Send(command, cancellationToken);
+            return Ok(result);
+        }
+        [HttpPost("movetasks")]
+        public async Task<IActionResult> MoveTasksAsync([FromBody] MoveTasksRequest request, CancellationToken cancellationToken)
+        {
+            var command = new MoveTasksCommand()
+            {
+                TaskIds = request.TaskIds,
+                SourceTeamId = request.sourceTeamId,
+                TargetTeamId = request.targetTeamId
+            };
             var result = await sender.Send(command, cancellationToken);
             return Ok(result);
         }

--- a/Valghalla.Internal.Application/Modules/Tasks/Commands/MoveTasksCommand.cs
+++ b/Valghalla.Internal.Application/Modules/Tasks/Commands/MoveTasksCommand.cs
@@ -1,0 +1,42 @@
+﻿using FluentValidation;
+
+using Valghalla.Application.Abstractions.Messaging;
+using Valghalla.Internal.Application.Modules.Tasks.Interfaces;
+
+namespace Valghalla.Internal.Application.Modules.Tasks.Commands
+{
+    public sealed record MoveTasksCommand() : ICommand<Response<bool>>
+    {
+        public string[]? TaskIds { get; set; }
+        public Guid? TargetTeamId { get; set; }
+        public Guid? SourceTeamId { get; set; }
+    }
+    public sealed class MoveTasksCommandValidator : AbstractValidator<MoveTasksCommand>
+    {
+        public MoveTasksCommandValidator()
+        {
+            RuleFor(x => x.SourceTeamId)
+                .NotEmpty();
+
+            RuleFor(x => x.TargetTeamId)
+                .NotEmpty();
+        }
+    }
+    internal class MoveTasksCommandHandler : ICommandHandler<MoveTasksCommand, Response<bool>>
+    {
+        private readonly IElectionWorkLocationTasksCommandRepository electionWorkLocationTasksCommandRepository;
+
+        public MoveTasksCommandHandler(IElectionWorkLocationTasksCommandRepository electionWorkLocationTasksCommandRepository)
+        {
+            this.electionWorkLocationTasksCommandRepository = electionWorkLocationTasksCommandRepository;
+        }
+
+        public async Task<Response<bool>> Handle(MoveTasksCommand command, CancellationToken cancellationToken)
+        {
+            var result = await electionWorkLocationTasksCommandRepository.MoveElectionWorkLocationTasksAsync(command, cancellationToken);
+          
+            return Response.Ok(result);
+        }
+
+    }
+}

--- a/Valghalla.Internal.Application/Modules/Tasks/Interfaces/IElectionWorkLocationTasksCommandRepository.cs
+++ b/Valghalla.Internal.Application/Modules/Tasks/Interfaces/IElectionWorkLocationTasksCommandRepository.cs
@@ -9,5 +9,6 @@ namespace Valghalla.Internal.Application.Modules.Tasks.Interfaces
         Task<bool> AssignCreatingParticipantToTaskAsync(AssignParticipantToTaskCommand command, IEnumerable<Guid> teamIds, CancellationToken cancellationToken);
         Task RemoveParticipantFromTaskAsync(RemoveParticipantFromTaskCommand command, CancellationToken cancellationToken);
         Task<Guid?> ReplyForParticipantAsync(ReplyForParticipantCommand command, CancellationToken cancellationToken);
+        Task<bool> MoveElectionWorkLocationTasksAsync(MoveTasksCommand command, CancellationToken cancellationToken);
     }
 }

--- a/Valghalla.Internal.Application/Modules/Tasks/Requests/MoveTasksRequest.cs
+++ b/Valghalla.Internal.Application/Modules/Tasks/Requests/MoveTasksRequest.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Valghalla.Internal.Application.Modules.Tasks.Requests
+{
+    public sealed record MoveTasksRequest
+    {
+        public string[]? TaskIds { get; set; }
+        public Guid? targetTeamId { get; set; }
+        public Guid? sourceTeamId { get; set; }
+    }
+}

--- a/Valghalla.Internal.Web/src/assets/i18n/da.json
+++ b/Valghalla.Internal.Web/src/assets/i18n/da.json
@@ -1019,7 +1019,8 @@
       "validation_rules_citizenship": "Deltager er ikke statsborger i det påkrævede land",
       "validation_rules_legal_adult": "Deltager er ikke myndig",
       "task_conflict": "Deltager er allerede tilmeldt en anden opgave på dette tidspunkt",
-      "get_tasks_filtered_options": "Fejl opstod ved hentning af opgavefiltre"
+      "get_tasks_filtered_options": "Fejl opstod ved hentning af opgavefiltre",
+      "tasks_moved": "Fejl opstod ved flytning af opgaver"
     },
     "success": {
       "distribute_work_location_tasks": "Opgaver er blevet fordelt på arbejdsstedet med succes",
@@ -1027,6 +1028,7 @@
       "remove_participant_from_task": "Deltager er blevet fjernet fra opgaven med succes",
       "reply_for_participant": "Svar for deltager er gennemført med succes",
       "task_link_copied": "Opgavelink er blevet kopieret til udklipsholderen med succes",
+      "tasks_moved": "Opgaver er blevet flyttet med succes",
       "filtered_tasks_link_copied": "Link til filtrerede opgaver er blevet kopieret til udklipsholderen med succes"
     },
     "work_location_tasks": {

--- a/Valghalla.Internal.Web/src/assets/i18n/en.json
+++ b/Valghalla.Internal.Web/src/assets/i18n/en.json
@@ -981,6 +981,7 @@
       "status_awaiting": "Awaiting",
       "missing": "MISSING",
       "rejected_invitations": "Rejected invitations",
+      "move_tasks": "Move tasks",
       "reply_on_behalf_of_user": "Reply on behalf of user",
       "participant_information_header": "Participant information",
       "participant_information_description": "Update information if needed",
@@ -995,6 +996,7 @@
       "copy_link": "Copy link",
       "create_participant": "Create participant",
       "assign_participant": "Assign participant",
+      "move_tasks": "Move tasks",
       "edit_participant": "Edit participant",
       "remove_participant": "Remove participant",
       "reply_for_participant": "Reply for participant",
@@ -1019,7 +1021,8 @@
       "validation_rules_citizenship": "Participant is not a citizen of the required country",
       "validation_rules_legal_adult": "Participant is not a legal adult",
       "task_conflict": "Participant is already registered for another task at the time of this task.",
-      "get_tasks_filtered_options": "Error occurred when fetching tasks filtered options"
+      "get_tasks_filtered_options": "Error occurred when fetching tasks filtered options",
+      "tasks_moved": "Error occurred when moving tasks"
     },
     "success": {
       "distribute_work_location_tasks": "Work location tasks has been distributed successfully",
@@ -1027,6 +1030,7 @@
       "remove_participant_from_task": "Participant has been removed from task successfully",
       "reply_for_participant": "Replying for participant successfully",
       "task_link_copied": "Task link has been copied to clipboard successfully",
+      "tasks_moved": "Tasks have been moved successfully",
       "filtered_tasks_link_copied": "Filtered tasks link has been copied to clipboard successfully"
     },
     "work_location_tasks": {

--- a/Valghalla.Internal.Web/src/features/tasks/components/work-location-tasks-overview/work-location-tasks-overview.component.html
+++ b/Valghalla.Internal.Web/src/features/tasks/components/work-location-tasks-overview/work-location-tasks-overview.component.html
@@ -1,133 +1,237 @@
-
-
 <app-card
-  [cardTitle]="(this.workLocation ? ('tasks.work_location_tasks.page_title' | transloco) + ' - ' + this.workLocation.title : (invalidWorkLocationId ? ('tasks.error.invalid_work_location' | transloco) : ''))"
-  [actionTitle]="invalidWorkLocationId ? '' : 'tasks.work_location_tasks.actions.distribute_tasks' | transloco"
-  [actionIcon]="invalidWorkLocationId ? '' : 'edit_note'" (action)="openDistributeTasks()">
-    <mat-form-field class="pb-4">
-    <mat-select [(ngModel)]="selectedDateIndex" [ngModelOptions]="{standalone: true}" [placeholder]="'tasks.labels.all_dates' | transloco" (selectionChange)="onDateChanged()">
-      <mat-option>{{'tasks.labels.all_dates' | transloco}}</mat-option>
+  [cardTitle]="
+    this.workLocation
+      ? ('tasks.work_location_tasks.page_title' | transloco) + ' - ' + this.workLocation.title
+      : invalidWorkLocationId
+        ? ('tasks.error.invalid_work_location' | transloco)
+        : ''
+  "
+  [actionTitle]="invalidWorkLocationId ? '' : ('tasks.work_location_tasks.actions.distribute_tasks' | transloco)"
+  [actionIcon]="invalidWorkLocationId ? '' : 'edit_note'"
+  (action)="openDistributeTasks()">
+  <mat-form-field class="pb-4">
+    <mat-select
+      [(ngModel)]="selectedDateIndex"
+      [ngModelOptions]="{ standalone: true }"
+      [placeholder]="'tasks.labels.all_dates' | transloco"
+      (selectionChange)="onDateChanged()">
+      <mat-option>{{ 'tasks.labels.all_dates' | transloco }}</mat-option>
       <mat-option *ngFor="let dailyWorkLocationTask of dailyWorkLocationTasks" [value]="dailyWorkLocationTask.index">
-          {{ dailyWorkLocationTask.tasksDate | date }}
+        {{ dailyWorkLocationTask.tasksDate | date }}
       </mat-option>
     </mat-select>
   </mat-form-field>
   <div class="w-full transition-[width] duration-500 overflow-auto max-h-[500px]">
-    <mat-table [dataSource]="selectedDateIndex != undefined && selectedDateIndex > -1 ? dailyWorkLocationTasks[selectedDateIndex].teams : allDatesWorkLocationTasks.teams" *ngIf="!loading">
-        <ng-container matColumnDef="team" sticky>
-            <mat-header-cell *matHeaderCellDef class="min-w-[200px]">{{'tasks.labels.team' | transloco}}</mat-header-cell>
-            <mat-cell *matCellDef="let taskInfo" class="min-w-[200px]">{{taskInfo.teamName}}</mat-cell>
-            <mat-cell mat-footer-cell *matFooterCellDef class="min-w-[200px] font-semibold">{{'shared.common.total' | transloco}}</mat-cell>
-        </ng-container>
-        <ng-container matColumnDef="total" stickyEnd>
-            <mat-header-cell *matHeaderCellDef class="min-w-[100px] font-semibold">{{'shared.common.total' | transloco}}</mat-header-cell>
-            <mat-cell *matCellDef="let taskInfo" class="min-w-[100px] font-semibold">
-                {{getTeamAssignedTasksCount(taskInfo)}}/{{getTeamAllTasksCount(taskInfo)}}
-            </mat-cell>
-            <mat-cell mat-footer-cell *matFooterCellDef class="min-w-[100px] font-semibold">
-                {{getSumAssignedTasksCount()}}/{{getSumAllTasksCount()}}
-            </mat-cell>
-        </ng-container>
-        <ng-container *ngFor="let taskType of workLocationTasksSummary.taskTypes" [matColumnDef]="taskType.id">
-            <mat-header-cell *matHeaderCellDef class="min-w-[125px]"><span [matTooltip]="taskType.title" matTooltipPosition="above">{{taskType.shortName}}</span></mat-header-cell>
-            <mat-cell *matCellDef="let taskInfo" class="min-w-[125px]">  
-                <span class="p-2" [ngClass]="taskInfo.taskTypes[workLocationTasksSummary.taskTypes.indexOf(taskType)].allTasksCount > 0 ? (taskInfo.taskTypes[workLocationTasksSummary.taskTypes.indexOf(taskType)].assignedTasksCount == taskInfo.taskTypes[workLocationTasksSummary.taskTypes.indexOf(taskType)].allTasksCount ? 'allAcceptedTasks' : (taskInfo.taskTypes[workLocationTasksSummary.taskTypes.indexOf(taskType)].awaitingTasksCount > 0 ? 'awaitingAcceptedTasks' : '')) : ''">
-                  {{taskInfo.taskTypes[workLocationTasksSummary.taskTypes.indexOf(taskType)].assignedTasksCount}}/{{taskInfo.taskTypes[workLocationTasksSummary.taskTypes.indexOf(taskType)].allTasksCount}}
-                </span>
-            </mat-cell>
-            <mat-cell mat-footer-cell *matFooterCellDef class="min-w-[125px] font-semibold">
-              <span class="p-2">
-                {{getTaskTypeAssignedTasksCount(taskType)}}/{{getTaskTypeAllTasksCount(taskType)}}
-              </span>
-            </mat-cell>
-        </ng-container>
-        
-        <mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></mat-header-row>
-        <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
-        <mat-footer-row *matFooterRowDef="displayedColumns; sticky: true"></mat-footer-row>
-    </mat-table>  
+    <mat-table
+      [dataSource]="
+        selectedDateIndex != undefined && selectedDateIndex > -1
+          ? dailyWorkLocationTasks[selectedDateIndex].teams
+          : allDatesWorkLocationTasks.teams
+      "
+      *ngIf="!loading">
+      <ng-container matColumnDef="team" sticky>
+        <mat-header-cell *matHeaderCellDef class="min-w-[200px]">{{ 'tasks.labels.team' | transloco }}</mat-header-cell>
+        <mat-cell *matCellDef="let taskInfo" class="min-w-[200px]">{{ taskInfo.teamName }}</mat-cell>
+        <mat-cell mat-footer-cell *matFooterCellDef class="min-w-[200px] font-semibold">{{
+          'shared.common.total' | transloco
+        }}</mat-cell>
+      </ng-container>
+      <ng-container matColumnDef="total" stickyEnd>
+        <mat-header-cell *matHeaderCellDef class="min-w-[100px] font-semibold">{{
+          'shared.common.total' | transloco
+        }}</mat-header-cell>
+        <mat-cell *matCellDef="let taskInfo" class="min-w-[100px] font-semibold">
+          {{ getTeamAssignedTasksCount(taskInfo) }}/{{ getTeamAllTasksCount(taskInfo) }}
+        </mat-cell>
+        <mat-cell mat-footer-cell *matFooterCellDef class="min-w-[100px] font-semibold">
+          {{ getSumAssignedTasksCount() }}/{{ getSumAllTasksCount() }}
+        </mat-cell>
+      </ng-container>
+      <ng-container *ngFor="let taskType of workLocationTasksSummary.taskTypes" [matColumnDef]="taskType.id">
+        <mat-header-cell *matHeaderCellDef class="min-w-[125px]"
+          ><span [matTooltip]="taskType.title" matTooltipPosition="above">{{
+            taskType.shortName
+          }}</span></mat-header-cell
+        >
+        <mat-cell *matCellDef="let taskInfo" class="min-w-[125px]">
+          <span
+            class="p-2"
+            [ngClass]="
+              taskInfo.taskTypes[workLocationTasksSummary.taskTypes.indexOf(taskType)].allTasksCount > 0
+                ? taskInfo.taskTypes[workLocationTasksSummary.taskTypes.indexOf(taskType)].assignedTasksCount ==
+                  taskInfo.taskTypes[workLocationTasksSummary.taskTypes.indexOf(taskType)].allTasksCount
+                  ? 'allAcceptedTasks'
+                  : taskInfo.taskTypes[workLocationTasksSummary.taskTypes.indexOf(taskType)].awaitingTasksCount > 0
+                    ? 'awaitingAcceptedTasks'
+                    : ''
+                : ''
+            ">
+            {{ taskInfo.taskTypes[workLocationTasksSummary.taskTypes.indexOf(taskType)].assignedTasksCount }}/{{
+              taskInfo.taskTypes[workLocationTasksSummary.taskTypes.indexOf(taskType)].allTasksCount
+            }}
+          </span>
+        </mat-cell>
+        <mat-cell mat-footer-cell *matFooterCellDef class="min-w-[125px] font-semibold">
+          <span class="p-2">
+            {{ getTaskTypeAssignedTasksCount(taskType) }}/{{ getTaskTypeAllTasksCount(taskType) }}
+          </span>
+        </mat-cell>
+      </ng-container>
+
+      <mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></mat-header-row>
+      <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
+      <mat-footer-row *matFooterRowDef="displayedColumns; sticky: true"></mat-footer-row>
+    </mat-table>
   </div>
   <div class="w-full" *appShowSkeleton="loading">
     <mat-accordion multi>
       <mat-expansion-panel *ngFor="let team of workLocationTasksSummary.teams; let teamIndex = index">
         <mat-expansion-panel-header class="bg-gray-100">
           <mat-panel-title>
-            <div class="font-semibold pr-12">{{team.name}}</div>
-            <div *ngFor="let taskType of (selectedDateIndex != undefined && selectedDateIndex > -1 ? dailyWorkLocationTasks[selectedDateIndex].teams[teamIndex].taskTypes : allDatesWorkLocationTasks.teams[teamIndex].taskTypes); let taskTypeIndex = index">
+            <div class="font-semibold pr-12">{{ team.name }}</div>
+            <div
+              *ngFor="
+                let taskType of selectedDateIndex != undefined && selectedDateIndex > -1
+                  ? dailyWorkLocationTasks[selectedDateIndex].teams[teamIndex].taskTypes
+                  : allDatesWorkLocationTasks.teams[teamIndex].taskTypes;
+                let taskTypeIndex = index
+              ">
               <span class="pr-8" *ngIf="taskType.allTasksCount > 0">
-                {{taskType.allTasksCount > 0 ? workLocationTasksSummary.taskTypes[taskTypeIndex].shortName + ': ' + taskType.assignedTasksCount + '/' + taskType.allTasksCount : ''}}
+                {{
+                  taskType.allTasksCount > 0
+                    ? workLocationTasksSummary.taskTypes[taskTypeIndex].shortName +
+                      ': ' +
+                      taskType.assignedTasksCount +
+                      '/' +
+                      taskType.allTasksCount
+                    : ''
+                }}
               </span>
             </div>
-          </mat-panel-title>          
+          </mat-panel-title>
         </mat-expansion-panel-header>
-        <div *appShowSkeleton="loading || (dailyTeamTasks && dailyTeamTasks[teamIndex] && dailyTeamTasks[teamIndex].loadingTasks)" class="pt-2 transition-[width] duration-500 overflow-auto">
+        <div
+          *appShowSkeleton="
+            loading || (dailyTeamTasks && dailyTeamTasks[teamIndex] && dailyTeamTasks[teamIndex].loadingTasks)
+          "
+          class="pt-2 transition-[width] duration-500 overflow-auto">
           <mat-table [dataSource]="dailyTeamTasks[teamIndex].displayingTasks">
             <ng-container matColumnDef="status">
               <mat-header-cell *matHeaderCellDef class="max-w-[70px] place-content-center"></mat-header-cell>
-              <mat-cell *matCellDef="let task" class="max-w-[70px] place-content-center">  
+              <mat-cell *matCellDef="let task" class="max-w-[70px] place-content-center">
                 <mat-icon class="text-base text-red-600" *ngIf="!task.participantId">circle</mat-icon>
-                <mat-icon class="text-base text-yellow-300" *ngIf="task.participantId && !task.accepted">circle</mat-icon>
+                <mat-icon class="text-base text-yellow-300" *ngIf="task.participantId && !task.accepted"
+                  >circle</mat-icon
+                >
                 <mat-icon class="text-base text-green-600" *ngIf="task.participantId && task.accepted">circle</mat-icon>
               </mat-cell>
             </ng-container>
             <ng-container matColumnDef="taskType">
-              <mat-header-cell *matHeaderCellDef class="flex-none min-w-[180px]">{{'tasks.labels.task_type' | transloco}}</mat-header-cell>
-              <mat-cell *matCellDef="let task" class="flex-none min-w-[180px]"> 
-                  {{task.taskTypeName}}
+              <mat-header-cell *matHeaderCellDef class="flex-none min-w-[180px]">{{
+                'tasks.labels.task_type' | transloco
+              }}</mat-header-cell>
+              <mat-cell *matCellDef="let task" class="flex-none min-w-[180px]">
+                {{ task.taskTypeName }}
               </mat-cell>
             </ng-container>
             <ng-container matColumnDef="date">
-              <mat-header-cell *matHeaderCellDef class="flex-none min-w-[125px] max-w-[125px]">{{'tasks.labels.task_date' | transloco}}</mat-header-cell>
-              <mat-cell *matCellDef="let task" class="flex-none min-w-[125px] max-w-[125px]">  
-                  {{task.taskDate | date}}
+              <mat-header-cell *matHeaderCellDef class="flex-none min-w-[125px] max-w-[125px]">{{
+                'tasks.labels.task_date' | transloco
+              }}</mat-header-cell>
+              <mat-cell *matCellDef="let task" class="flex-none min-w-[125px] max-w-[125px]">
+                {{ task.taskDate | date }}
               </mat-cell>
             </ng-container>
             <ng-container matColumnDef="participant">
-              <mat-header-cell *matHeaderCellDef class="flex-none min-w-[200px]">{{'tasks.labels.participant' | transloco}}</mat-header-cell>
-              <mat-cell *matCellDef="let task" class="flex-none min-w-[200px]">  
-                  {{task.participantName ? task.participantName : ('tasks.labels.missing' | transloco)}}
+              <mat-header-cell *matHeaderCellDef class="flex-none min-w-[200px]">{{
+                'tasks.labels.participant' | transloco
+              }}</mat-header-cell>
+              <mat-cell *matCellDef="let task" class="flex-none min-w-[200px]">
+                {{ task.participantName ? task.participantName : ('tasks.labels.missing' | transloco) }}
               </mat-cell>
             </ng-container>
             <ng-container matColumnDef="actions">
               <mat-header-cell *matHeaderCellDef></mat-header-cell>
               <mat-cell *matCellDef="let task" class="place-content-end task-buttons">
                 <div class="flex flex-wrap">
-                  <button *ngIf="!task.participantId" mat-flat-button extended color="primary" class="mt-2 mb-2 mr-2 task-button" [disabled]="task.isUpdating" (click)="copyTaskLink(task.taskDetailsPageUrl)">
+                  <button
+                    *ngIf="!task.participantId"
+                    mat-flat-button
+                    extended
+                    color="primary"
+                    class="mt-2 mb-2 mr-2 task-button"
+                    [disabled]="task.isUpdating"
+                    (click)="copyTaskLink(task.taskDetailsPageUrl)">
                     <mat-icon *ngIf="!task.isUpdating">link</mat-icon>
                     <span *ngIf="!task.isUpdating">{{ 'tasks.actions.copy_task_link' | transloco }}</span>
                     <mat-icon *ngIf="task.isUpdating">
                       <mat-spinner color="primary" diameter="18"></mat-spinner>
                     </mat-icon>
                   </button>
-                  <button *ngIf="!task.participantId" mat-flat-button extended color="primary" class="mt-2 mb-2 mr-2 task-button" [disabled]="task.isUpdating" (click)="openParticipantCreating(task.id)">
+                  <button
+                    *ngIf="!task.participantId"
+                    mat-flat-button
+                    extended
+                    color="primary"
+                    class="mt-2 mb-2 mr-2 task-button"
+                    [disabled]="task.isUpdating"
+                    (click)="openParticipantCreating(task.id)">
                     <mat-icon *ngIf="!task.isUpdating">add_circle</mat-icon>
                     <span *ngIf="!task.isUpdating">{{ 'tasks.actions.create_participant' | transloco }}</span>
                     <mat-icon *ngIf="task.isUpdating">
                       <mat-spinner color="primary" diameter="18"></mat-spinner>
                     </mat-icon>
                   </button>
-                  <button *ngIf="!task.participantId" mat-flat-button extended color="primary" class="mt-2 mb-2 mr-2 task-button" [disabled]="task.isUpdating" (click)="openAssignParticipantDialog(task, teamIndex)">
+                  <button
+                    *ngIf="!task.participantId"
+                    mat-flat-button
+                    extended
+                    color="primary"
+                    class="mt-2 mb-2 mr-2 task-button"
+                    [disabled]="task.isUpdating"
+                    (click)="openAssignParticipantDialog(task, teamIndex)">
                     <mat-icon *ngIf="!task.isUpdating">add_circle</mat-icon>
                     <span *ngIf="!task.isUpdating">{{ 'tasks.actions.assign_participant' | transloco }}</span>
                     <mat-icon *ngIf="task.isUpdating">
                       <mat-spinner color="primary" diameter="18"></mat-spinner>
                     </mat-icon>
                   </button>
-                  <button *ngIf="task.participantId && !task.accepted" mat-flat-button extended color="accent" class="mt-2 mb-2 mr-2 task-button" [disabled]="task.isUpdating" (click)="openReplyForParticipant(task.id)">
+                  <button
+                    *ngIf="task.participantId && !task.accepted"
+                    mat-flat-button
+                    extended
+                    color="accent"
+                    class="mt-2 mb-2 mr-2 task-button"
+                    [disabled]="task.isUpdating"
+                    (click)="openReplyForParticipant(task.id)">
                     <mat-icon *ngIf="!task.isUpdating">edit_note</mat-icon>
                     <span *ngIf="!task.isUpdating">{{ 'tasks.actions.reply_for_participant' | transloco }}</span>
                     <mat-icon *ngIf="task.isUpdating">
                       <mat-spinner color="primary" diameter="18"></mat-spinner>
                     </mat-icon>
                   </button>
-                  <button *ngIf="task.participantId" mat-flat-button extended color="primary" class="mt-2 mb-2 mr-2 task-button" [disabled]="task.isUpdating" (click)="openParticipantEditing(task.participantId)">
+                  <button
+                    *ngIf="task.participantId"
+                    mat-flat-button
+                    extended
+                    color="primary"
+                    class="mt-2 mb-2 mr-2 task-button"
+                    [disabled]="task.isUpdating"
+                    (click)="openParticipantEditing(task.participantId)">
                     <mat-icon *ngIf="!task.isUpdating">person</mat-icon>
                     <span *ngIf="!task.isUpdating">{{ 'tasks.actions.edit_participant' | transloco }}</span>
                     <mat-icon *ngIf="task.isUpdating">
                       <mat-spinner color="primary" diameter="18"></mat-spinner>
                     </mat-icon>
                   </button>
-                  <button *ngIf="task.participantId" mat-flat-button extended color="warn" class="mt-2 mb-2 mr-2 task-button" [disabled]="task.isUpdating"  (click)="removeParticipant(task, teamIndex)">
+                  <button
+                    *ngIf="task.participantId"
+                    mat-flat-button
+                    extended
+                    color="warn"
+                    class="mt-2 mb-2 mr-2 task-button"
+                    [disabled]="task.isUpdating"
+                    (click)="removeParticipant(task, teamIndex)">
                     <mat-icon *ngIf="!task.isUpdating">remove_circle</mat-icon>
                     <span *ngIf="!task.isUpdating">{{ 'tasks.actions.remove_participant' | transloco }}</span>
                     <mat-icon *ngIf="task.isUpdating">
@@ -138,11 +242,15 @@
               </mat-cell>
             </ng-container>
             <mat-header-row *matHeaderRowDef="teamTasksColumns"></mat-header-row>
-            <mat-row *matRowDef="let row; columns: teamTasksColumns;"></mat-row>
-          </mat-table>          
+            <mat-row *matRowDef="let row; columns: teamTasksColumns"></mat-row>
+          </mat-table>
         </div>
-        <div *appShowSkeleton="loading || (dailyTeamTasks && dailyTeamTasks[teamIndex] && dailyTeamTasks[teamIndex].loadingRejectedTasks)" class="pt-2 transition-[width] duration-500 overflow-auto">
-          <h3 class="pb-2">{{'tasks.labels.rejected_invitations' | transloco}}</h3>
+        <div
+          *appShowSkeleton="
+            loading || (dailyTeamTasks && dailyTeamTasks[teamIndex] && dailyTeamTasks[teamIndex].loadingRejectedTasks)
+          "
+          class="pt-2 transition-[width] duration-500 overflow-auto">
+          <h3 class="pb-2">{{ 'tasks.labels.rejected_invitations' | transloco }}</h3>
           <mat-table [dataSource]="dailyTeamTasks[teamIndex].rejectedDisplayingTasks">
             <ng-container matColumnDef="status">
               <mat-header-cell *matHeaderCellDef class="max-w-[70px] place-content-center"></mat-header-cell>
@@ -151,40 +259,81 @@
               </mat-cell>
             </ng-container>
             <ng-container matColumnDef="taskType">
-              <mat-header-cell *matHeaderCellDef class="flex-none min-w-[180px]">{{'tasks.labels.task_type' | transloco}}</mat-header-cell>
+              <mat-header-cell *matHeaderCellDef class="flex-none min-w-[180px]">{{
+                'tasks.labels.task_type' | transloco
+              }}</mat-header-cell>
               <mat-cell *matCellDef="let task" class="flex-none min-w-[180px]">
-                  {{task.taskTypeName}}
+                {{ task.taskTypeName }}
               </mat-cell>
             </ng-container>
             <ng-container matColumnDef="date">
-              <mat-header-cell *matHeaderCellDef class="flex-none min-w-[125px] max-w-[125px]">{{'tasks.labels.task_date' | transloco}}</mat-header-cell>
-              <mat-cell *matCellDef="let task" class="flex-none min-w-[125px] max-w-[125px]">  
-                  {{task.taskDate | date}}
+              <mat-header-cell *matHeaderCellDef class="flex-none min-w-[125px] max-w-[125px]">{{
+                'tasks.labels.task_date' | transloco
+              }}</mat-header-cell>
+              <mat-cell *matCellDef="let task" class="flex-none min-w-[125px] max-w-[125px]">
+                {{ task.taskDate | date }}
               </mat-cell>
             </ng-container>
             <ng-container matColumnDef="participant">
-              <mat-header-cell *matHeaderCellDef class="flex-none min-w-[200px]">{{'tasks.labels.participant' | transloco}}</mat-header-cell>
-              <mat-cell *matCellDef="let task" class="flex-none min-w-[200px]">  
-                  {{task.participantName ? task.participantName : ('tasks.labels.missing' | transloco)}}
+              <mat-header-cell *matHeaderCellDef class="flex-none min-w-[200px]">{{
+                'tasks.labels.participant' | transloco
+              }}</mat-header-cell>
+              <mat-cell *matCellDef="let task" class="flex-none min-w-[200px]">
+                {{ task.participantName ? task.participantName : ('tasks.labels.missing' | transloco) }}
               </mat-cell>
             </ng-container>
             <ng-container matColumnDef="actions">
               <mat-header-cell *matHeaderCellDef></mat-header-cell>
-              <mat-cell *matCellDef="let task" class="place-content-end">
-              </mat-cell>
+              <mat-cell *matCellDef="let task" class="place-content-end"> </mat-cell>
             </ng-container>
             <mat-header-row *matHeaderRowDef="teamTasksColumns"></mat-header-row>
-            <mat-row *matRowDef="let row; columns: teamTasksColumns;"></mat-row>
+            <mat-row *matRowDef="let row; columns: teamTasksColumns"></mat-row>
           </mat-table>
-      </div>
+          <h3 class="pb-2">{{ 'tasks.labels.move_tasks' | transloco }}</h3>
+          <div class="flex items-center gap-4 pb-4">
+            <mat-form-field class="pb-0 mb-0">
+              <mat-select
+                [(ngModel)]="selectedTeam"
+                [ngModelOptions]="{ standalone: true }"
+                [placeholder]="'tasks.labels.team' | transloco"
+                (selectionChange)="onTeamChanged()">
+                <mat-option>{{ 'tasks.labels.team' | transloco }}</mat-option>
+                <mat-option *ngFor="let team of workLocationTasksSummary.teams" [value]="team.id">
+                  {{ team.name }}
+                </mat-option>
+              </mat-select>
+            </mat-form-field>
+            <button
+              mat-flat-button
+              extended
+              color="primary"
+              class="mt-2 mb-2 mr-2 move-task-button"
+              (click)="moveVacantTasksToOtherTeam(team.id, teamIndex)"
+              [disabled]="!selectedTeam || (this.targetTeamId && this.targetTeamId === team.id)"
+              [disableRipple]="!selectedTeam || (this.targetTeamId && this.targetTeamId === team.id)">
+              <mat-icon>arrow_circle_right</mat-icon>
+              <span>{{ 'tasks.actions.move_tasks' | transloco }}</span>
+              <mat-icon *ngIf="selectedTeam && (!this.targetTeamId || this.targetTeamId !== team.id)">
+                <mat-spinner color="primary" diameter="18"></mat-spinner>
+              </mat-icon>
+            </button>
+          </div>
+        </div>
       </mat-expansion-panel>
     </mat-accordion>
   </div>
   <div class="hidden">
     <form [formGroup]="form">
-      <app-participant-picker (closeEvent)="onParticipantPickerClose()" (submitEvent)="onParticipantSelected()"
-        [label]="('tasks.actions.assign_participant' | transloco) + (assigningTask ? ' - ' + assigningTask.taskTypeName + ' - ' + (assigningTask.taskDate | date): '')"
-        [multiple]="false" [visible]="this.openAddParticipant" formControlName="selectedParticipantIds"></app-participant-picker>
+      <app-participant-picker
+        (closeEvent)="onParticipantPickerClose()"
+        (submitEvent)="onParticipantSelected()"
+        [label]="
+          ('tasks.actions.assign_participant' | transloco) +
+          (assigningTask ? ' - ' + assigningTask.taskTypeName + ' - ' + (assigningTask.taskDate | date) : '')
+        "
+        [multiple]="false"
+        [visible]="this.openAddParticipant"
+        formControlName="selectedParticipantIds"></app-participant-picker>
     </form>
   </div>
 </app-card>

--- a/Valghalla.Internal.Web/src/features/tasks/components/work-location-tasks-overview/work-location-tasks-overview.component.ts
+++ b/Valghalla.Internal.Web/src/features/tasks/components/work-location-tasks-overview/work-location-tasks-overview.component.ts
@@ -18,6 +18,8 @@ import { TaskAssignment } from '../../models/task-assignment';
 import { AssignParticipantToTaskRequest } from '../../models/assign-participant-to-task-request';
 import { RemoveParticipantFromTaskRequest } from '../../models/remove-participant-from-task-request';
 import { WorkLocationTasksHttpService } from '../../services/work-location-tasks-http.service';
+import { TeamShared } from 'src/shared/models/team/team-shared';
+import { MoveTasksRequest } from '../../models/move-tasks-request';
 
 interface UpdatingTaskAssignment extends TaskAssignment {
   isUpdating?: boolean;
@@ -60,315 +62,320 @@ interface DailyTeamTasks {
   providers: [WorkLocationTasksHttpService, LinkHttpService]
 })
 export class WorkLocationTasksOverviewComponent implements OnInit {
-    private readonly subs = new SubSink();
 
-    displayedColumns: Array<string> = ['team'];
+  private readonly subs = new SubSink();
 
-    teamTasksColumns: Array<string> = ['status', 'taskType', 'date', 'participant', 'actions'];
+  displayedColumns: Array<string> = ['team'];
 
-    workLocation: WorkLocationInfo;
+  teamTasksColumns: Array<string> = ['status', 'taskType', 'date', 'participant', 'actions'];
 
-    workLocationTasksSummary: WorkLocationTasksSummary;
+  workLocation: WorkLocationInfo;
 
-    dailyWorkLocationTasks: Array<DailyWorkLocationTasks> = [];
+  workLocationTasksSummary: WorkLocationTasksSummary;
 
-    allDatesWorkLocationTasks: DailyWorkLocationTasks;
+  dailyWorkLocationTasks: Array<DailyWorkLocationTasks> = [];
 
-    dailyTeamTasks: Array<DailyTeamTasks> = [];
+  allDatesWorkLocationTasks: DailyWorkLocationTasks;
 
-    selectedDate: any;
+  dailyTeamTasks: Array<DailyTeamTasks> = [];
 
-    itemId: string;
+  selectedDate: any;
 
-    election?: ElectionShared;
+  itemId: string;
 
-    loading = true;
+  election?: ElectionShared;
 
-    openAddParticipant = false;
+  loading = true;
 
-    invalidWorkLocationId = false;
+  openAddParticipant = false;
 
-    selectedDateIndex = -1;
+  invalidWorkLocationId = false;
 
-    assigningTask: UpdatingTaskAssignment;
+  selectedDateIndex = -1;
 
-    selectedTeamIndex: number;
+  assigningTask: UpdatingTaskAssignment;
 
-    readonly form = this.formBuilder.group({
-      selectedParticipantIds: [[] as string[]],
-    });
+  selectedTeamIndex: number;
 
-    constructor(
-        private dialog: MatDialog,
-        private breadcrumbService: BreadcrumbService,
-        private translocoService: TranslocoService,
-        private router: Router,
-        private route: ActivatedRoute,
-        private clipboard: Clipboard,
-        private globalStateService: GlobalStateService,
-        private notificationService: NotificationService,
-        private formBuilder: FormBuilder,
-        private workLocationTasksHttpService: WorkLocationTasksHttpService,
-        private linkHttpService: LinkHttpService,
-    ) {}
+  selectedTeam: TeamShared;
 
-    ngOnInit(): void {
-        this.itemId = this.route.snapshot.paramMap.get(RoutingNodes.WorkLocationId);
-        this.subs.sink = this.globalStateService.election$.subscribe((election) => {
-          this.election = election;
-          this.subs.sink = this.workLocationTasksHttpService.getWorkLocation(this.itemId, this.election.id).subscribe((res) => {
-            this.workLocation = res.data;
-            if (this.workLocation) {
-                this.invalidWorkLocationId = false;
-                this.breadcrumbService.set('/' + RoutingNodes.TasksOnWorkLocation + '/:' + RoutingNodes.WorkLocationId, this.translocoService.translate('tasks.work_location_tasks.tasks_on') + ' ' + this.workLocation.title);
-                this.subs.sink = this.workLocationTasksHttpService.getWorkLocationTasksSummary(this.itemId, this.election.id).subscribe((taskTypesSummaryResult) => {               
-                  this.workLocationTasksSummary = taskTypesSummaryResult.data;
-                  this.workLocationTasksSummary.taskTypes.forEach((taskType) => {
-                    this.displayedColumns.push(taskType.id);
-                  });
-                  this.workLocationTasksSummary.teams.forEach((team, index) => {
-                    this.dailyTeamTasks.push( { index: index, teamId: team.id, tasks: [], displayingTasks: [], rejectedTasks: [], rejectedDisplayingTasks: [], loadingTasks: true, loadingRejectedTasks: true });
-                  });
-                  this.displayedColumns.push('total');
-                  this.buildWorkLocationTasksSummary();
-                  this.buildTeamTasksSummary();
-                  this.buildRejectedTeamTasksSummary();
-                });
-            }
-            else {
-                this.invalidWorkLocationId = true;
-                this.breadcrumbService.set('/' + RoutingNodes.TasksOnWorkLocation + '/:' + RoutingNodes.WorkLocationId, '');
-            }
+  targetTeamId: any;
+
+  readonly form = this.formBuilder.group({
+    selectedParticipantIds: [[] as string[]],
+  });
+
+  constructor(
+    private dialog: MatDialog,
+    private breadcrumbService: BreadcrumbService,
+    private translocoService: TranslocoService,
+    private router: Router,
+    private route: ActivatedRoute,
+    private clipboard: Clipboard,
+    private globalStateService: GlobalStateService,
+    private notificationService: NotificationService,
+    private formBuilder: FormBuilder,
+    private workLocationTasksHttpService: WorkLocationTasksHttpService,
+    private linkHttpService: LinkHttpService,
+  ) { }
+
+  ngOnInit(): void {
+    this.itemId = this.route.snapshot.paramMap.get(RoutingNodes.WorkLocationId);
+    this.subs.sink = this.globalStateService.election$.subscribe((election) => {
+      this.election = election;
+      this.subs.sink = this.workLocationTasksHttpService.getWorkLocation(this.itemId, this.election.id).subscribe((res) => {
+        this.workLocation = res.data;
+        if (this.workLocation) {
+          this.invalidWorkLocationId = false;
+          this.breadcrumbService.set('/' + RoutingNodes.TasksOnWorkLocation + '/:' + RoutingNodes.WorkLocationId, this.translocoService.translate('tasks.work_location_tasks.tasks_on') + ' ' + this.workLocation.title);
+          this.subs.sink = this.workLocationTasksHttpService.getWorkLocationTasksSummary(this.itemId, this.election.id).subscribe((taskTypesSummaryResult) => {
+            this.workLocationTasksSummary = taskTypesSummaryResult.data;
+            this.workLocationTasksSummary.taskTypes.forEach((taskType) => {
+              this.displayedColumns.push(taskType.id);
+            });
+            this.workLocationTasksSummary.teams.forEach((team, index) => {
+              this.dailyTeamTasks.push({ index: index, teamId: team.id, tasks: [], displayingTasks: [], rejectedTasks: [], rejectedDisplayingTasks: [], loadingTasks: true, loadingRejectedTasks: true });
+            });
+            this.displayedColumns.push('total');
+            this.buildWorkLocationTasksSummary();
+            this.buildTeamTasksSummary();
+            this.buildRejectedTeamTasksSummary();
           });
-        });
-    }
+        }
+        else {
+          this.invalidWorkLocationId = true;
+          this.breadcrumbService.set('/' + RoutingNodes.TasksOnWorkLocation + '/:' + RoutingNodes.WorkLocationId, '');
+        }
+      });
+    });
+  }
 
-    buildWorkLocationTasksSummary() {
-      this.allDatesWorkLocationTasks = {
+  buildWorkLocationTasksSummary() {
+    this.allDatesWorkLocationTasks = {
+      teams: []
+    };
+
+    const tasksDate: Date = new Date(this.workLocationTasksSummary.electionEndDate);
+    let index = 0;
+    while (tasksDate >= new Date(this.workLocationTasksSummary.electionStartDate)) {
+      const clonedTasksDate = new Date(tasksDate);
+      var dailyWorkLocationTasksItem: DailyWorkLocationTasks = {
+        tasksDate: clonedTasksDate,
+        index: index,
         teams: []
       };
-
-      const tasksDate: Date = new Date(this.workLocationTasksSummary.electionEndDate);
-      let index = 0;
-      while (tasksDate >= new Date(this.workLocationTasksSummary.electionStartDate)) {
-        const clonedTasksDate = new Date(tasksDate);        
-        var dailyWorkLocationTasksItem: DailyWorkLocationTasks = {
-          tasksDate: clonedTasksDate,
-          index: index,
-          teams: []
+      this.workLocationTasksSummary.teams.forEach((team, teamIndex) => {
+        const taskTypesSummary: TeamTasksSummary = {
+          teamId: team.id,
+          teamName: team.name,
+          taskTypes: []
         };
-        this.workLocationTasksSummary.teams.forEach((team, teamIndex) => {
-          const taskTypesSummary: TeamTasksSummary = {
+        if (this.allDatesWorkLocationTasks.teams.length <= teamIndex) {
+          const allDatesTaskTypesSummary: TeamTasksSummary = {
             teamId: team.id,
             teamName: team.name,
             taskTypes: []
           };
-          if (this.allDatesWorkLocationTasks.teams.length <= teamIndex) {
-            const allDatesTaskTypesSummary: TeamTasksSummary = {
-              teamId: team.id,
-              teamName: team.name,
-              taskTypes: []
-            };
-            this.allDatesWorkLocationTasks.teams.push(allDatesTaskTypesSummary);
-          }
-          this.workLocationTasksSummary.taskTypes.forEach((taskType, taskTypeIndex) => {
-            const foundTasks = this.workLocationTasksSummary.tasks.filter(t => t.teamId == team.id && t.taskTypeId == taskType.id && new Date(t.tasksDate).valueOf() === tasksDate.valueOf());
+          this.allDatesWorkLocationTasks.teams.push(allDatesTaskTypesSummary);
+        }
+        this.workLocationTasksSummary.taskTypes.forEach((taskType, taskTypeIndex) => {
+          const foundTasks = this.workLocationTasksSummary.tasks.filter(t => t.teamId == team.id && t.taskTypeId == taskType.id && new Date(t.tasksDate).valueOf() === tasksDate.valueOf());
 
-            const taskTypeTasksSummary: TaskTypeTasksSummary = {
+          const taskTypeTasksSummary: TaskTypeTasksSummary = {
+            taskTypeId: taskType.id,
+            assignedTasksCount: foundTasks && foundTasks.length > 0 ? foundTasks[0].assignedTasksCount : 0,
+            awaitingTasksCount: foundTasks && foundTasks.length > 0 ? foundTasks[0].awaitingTasksCount : 0,
+            allTasksCount: foundTasks && foundTasks.length > 0 ? foundTasks[0].allTasksCount : 0,
+          };
+          taskTypesSummary.taskTypes.push(taskTypeTasksSummary);
+
+          if (this.allDatesWorkLocationTasks.teams[teamIndex].taskTypes.length <= taskTypeIndex) {
+            const allDatesTaskTypeTasksSummary: TaskTypeTasksSummary = {
               taskTypeId: taskType.id,
               assignedTasksCount: foundTasks && foundTasks.length > 0 ? foundTasks[0].assignedTasksCount : 0,
               awaitingTasksCount: foundTasks && foundTasks.length > 0 ? foundTasks[0].awaitingTasksCount : 0,
-              allTasksCount: foundTasks && foundTasks.length > 0 ? foundTasks[0].allTasksCount : 0,            
+              allTasksCount: foundTasks && foundTasks.length > 0 ? foundTasks[0].allTasksCount : 0,
             };
-            taskTypesSummary.taskTypes.push(taskTypeTasksSummary);
-
-            if (this.allDatesWorkLocationTasks.teams[teamIndex].taskTypes.length <= taskTypeIndex) {
-              const allDatesTaskTypeTasksSummary: TaskTypeTasksSummary = {
-                taskTypeId: taskType.id,
-                assignedTasksCount: foundTasks && foundTasks.length > 0 ? foundTasks[0].assignedTasksCount : 0,
-                awaitingTasksCount: foundTasks && foundTasks.length > 0 ? foundTasks[0].awaitingTasksCount : 0,
-                allTasksCount: foundTasks && foundTasks.length > 0 ? foundTasks[0].allTasksCount : 0,     
-              };
-              this.allDatesWorkLocationTasks.teams[teamIndex].taskTypes.push(allDatesTaskTypeTasksSummary);
-            }
-            else if (foundTasks && foundTasks.length > 0) {
-              this.allDatesWorkLocationTasks.teams[teamIndex].taskTypes[taskTypeIndex].assignedTasksCount += foundTasks[0].assignedTasksCount;
-              this.allDatesWorkLocationTasks.teams[teamIndex].taskTypes[taskTypeIndex].awaitingTasksCount += foundTasks[0].awaitingTasksCount;
-              this.allDatesWorkLocationTasks.teams[teamIndex].taskTypes[taskTypeIndex].allTasksCount += foundTasks[0].allTasksCount;
-            }
-          });
-          dailyWorkLocationTasksItem.teams.push(taskTypesSummary);
+            this.allDatesWorkLocationTasks.teams[teamIndex].taskTypes.push(allDatesTaskTypeTasksSummary);
+          }
+          else if (foundTasks && foundTasks.length > 0) {
+            this.allDatesWorkLocationTasks.teams[teamIndex].taskTypes[taskTypeIndex].assignedTasksCount += foundTasks[0].assignedTasksCount;
+            this.allDatesWorkLocationTasks.teams[teamIndex].taskTypes[taskTypeIndex].awaitingTasksCount += foundTasks[0].awaitingTasksCount;
+            this.allDatesWorkLocationTasks.teams[teamIndex].taskTypes[taskTypeIndex].allTasksCount += foundTasks[0].allTasksCount;
+          }
         });
-        
-        this.dailyWorkLocationTasks.push(dailyWorkLocationTasksItem);
-        tasksDate.setDate(tasksDate.getDate() - 1);
-        index++;
-      }
-      
-      if (this.selectedDateIndex >= 0) {
-        this.dailyTeamTasks.forEach((team) => {
-          team.displayingTasks = team.tasks.filter(t => (new Date(t.taskDate)).valueOf() === this.dailyWorkLocationTasks[this.selectedDateIndex].tasksDate.valueOf());
-          team.rejectedDisplayingTasks = team.rejectedTasks.filter(t => (new Date(t.taskDate)).valueOf() === this.dailyWorkLocationTasks[this.selectedDateIndex].tasksDate.valueOf());
-        });
-      }
+        dailyWorkLocationTasksItem.teams.push(taskTypesSummary);
+      });
 
-      this.loading = false;
+      this.dailyWorkLocationTasks.push(dailyWorkLocationTasksItem);
+      tasksDate.setDate(tasksDate.getDate() - 1);
+      index++;
     }
 
-    buildTeamTasksSummary() {
+    if (this.selectedDateIndex >= 0) {
       this.dailyTeamTasks.forEach((team) => {
-        this.workLocationTasksHttpService.getTeamTasks(team.teamId, this.itemId, this.election.id, false).subscribe((teamTasksResult) => { 
-          team.tasks = teamTasksResult.data;
-          team.displayingTasks = teamTasksResult.data;
-          team.loadingTasks = false;
-        });
+        team.displayingTasks = team.tasks.filter(t => (new Date(t.taskDate)).valueOf() === this.dailyWorkLocationTasks[this.selectedDateIndex].tasksDate.valueOf());
+        team.rejectedDisplayingTasks = team.rejectedTasks.filter(t => (new Date(t.taskDate)).valueOf() === this.dailyWorkLocationTasks[this.selectedDateIndex].tasksDate.valueOf());
       });
     }
 
-    buildRejectedTeamTasksSummary() {
-      this.dailyTeamTasks.forEach((team) => {
-        this.workLocationTasksHttpService.getTeamTasks(team.teamId, this.itemId, this.election.id, true).subscribe((teamTasksResult) => { 
-          team.rejectedTasks = teamTasksResult.data;
-          team.rejectedDisplayingTasks = teamTasksResult.data;
-          team.loadingRejectedTasks = false;
-        });
-      });
-    }
-
-    onDateChanged() {
-      if (this.selectedDateIndex >= 0) {
-        this.dailyTeamTasks.forEach((team) => {
-          team.displayingTasks = team.tasks.filter(t => (new Date(t.taskDate)).valueOf() === this.dailyWorkLocationTasks[this.selectedDateIndex].tasksDate.valueOf());
-          team.rejectedDisplayingTasks = team.rejectedTasks.filter(t => (new Date(t.taskDate)).valueOf() === this.dailyWorkLocationTasks[this.selectedDateIndex].tasksDate.valueOf());
-        });
-      }
-      else {
-        this.dailyTeamTasks.forEach((team) => {
-          team.displayingTasks = team.tasks;
-          team.rejectedDisplayingTasks = team.rejectedTasks;
-        });
-      }
-    }
-
-    getTeamAssignedTasksCount(taskInfo) {
-      return taskInfo.taskTypes.map(t => t.assignedTasksCount).reduce((acc, value) => acc + value, 0);
-    }
-
-    getTeamAllTasksCount(taskInfo) {
-      return taskInfo.taskTypes.map(t => t.allTasksCount).reduce((acc, value) => acc + value, 0);
-    }
-
-    getTaskTypeAssignedTasksCount(taskType) {
-      const dailyWorkLocationTask = this.selectedDateIndex > - 1 ? this.dailyWorkLocationTasks[this.selectedDateIndex] : this.allDatesWorkLocationTasks;
-      let assignedTasksCount = 0;
-      dailyWorkLocationTask.teams.forEach((team) => {
-        const foundTaskTypes = team.taskTypes.filter(t => t.taskTypeId == taskType.id);
-        if (foundTaskTypes && foundTaskTypes.length > 0) {
-          assignedTasksCount += foundTaskTypes[0].assignedTasksCount;
-        }
-      })
-      return assignedTasksCount;
-    }
-
-    getTaskTypeAllTasksCount(taskType) {
-      const dailyWorkLocationTask = this.selectedDateIndex > - 1 ? this.dailyWorkLocationTasks[this.selectedDateIndex] : this.allDatesWorkLocationTasks;
-      let allTasksCount = 0;
-      dailyWorkLocationTask.teams.forEach((team) => {
-        const foundTaskTypes = team.taskTypes.filter(t => t.taskTypeId == taskType.id);
-        if (foundTaskTypes && foundTaskTypes.length > 0) {
-          allTasksCount += foundTaskTypes[0].allTasksCount;
-        }
-      })
-      return allTasksCount;
-    }
-
-    getSumAssignedTasksCount() {
-      const dailyWorkLocationTask = this.selectedDateIndex > - 1 ? this.dailyWorkLocationTasks[this.selectedDateIndex] : this.allDatesWorkLocationTasks;
-      let assignedTasksCount = 0;
-      dailyWorkLocationTask.teams.forEach((team) => {
-        team.taskTypes.forEach((taskType) => {
-          assignedTasksCount += taskType.assignedTasksCount;
-        })
-      })
-      return assignedTasksCount;
-    }
-
-    getSumAllTasksCount() {
-      const dailyWorkLocationTask = this.selectedDateIndex > - 1 ? this.dailyWorkLocationTasks[this.selectedDateIndex] : this.allDatesWorkLocationTasks;
-      let allTasksCount = 0;
-      dailyWorkLocationTask.teams.forEach((team) => {
-        team.taskTypes.forEach((taskType) => {
-          allTasksCount += taskType.allTasksCount;
-        })
-      })
-      return allTasksCount;
-    }
-
-    openDistributeTasks() {
-        this.router.navigate([RoutingNodes.TasksOnWorkLocation, this.itemId, RoutingNodes.Link_Distribute]);
-    }
-
-    openParticipantEditing(participantId: string) {
-      this.router.navigate([RoutingNodes.Participant, RoutingNodes.Link_Edit, participantId]);
-    }
-
-    openParticipantCreating(taskId: string) {
-      this.router.navigate([RoutingNodes.Participant, RoutingNodes.Link_Create, this.itemId, taskId]);
-    }
-
-    openReplyForParticipant(taskId: string) {
-      this.router.navigate([RoutingNodes.TasksOnWorkLocation, this.itemId, RoutingNodes.ReplyForParticipant, taskId]);
+    this.loading = false;
   }
 
-    openAssignParticipantDialog(task: UpdatingTaskAssignment, teamIndex: number) {
-      this.assigningTask = task;
-      this.selectedTeamIndex = teamIndex;
-      this.form.value.selectedParticipantIds = [];
-      this.openAddParticipant = true;
-    }
+  buildTeamTasksSummary() {
+    this.dailyTeamTasks.forEach((team) => {
+      this.workLocationTasksHttpService.getTeamTasks(team.teamId, this.itemId, this.election.id, false).subscribe((teamTasksResult) => {
+        team.tasks = teamTasksResult.data;
+        team.displayingTasks = teamTasksResult.data;
+        team.loadingTasks = false;
+      });
+    });
+  }
 
-    onParticipantPickerClose() {
-      this.openAddParticipant = false;
-    }
+  buildRejectedTeamTasksSummary() {
+    this.dailyTeamTasks.forEach((team) => {
+      this.workLocationTasksHttpService.getTeamTasks(team.teamId, this.itemId, this.election.id, true).subscribe((teamTasksResult) => {
+        team.rejectedTasks = teamTasksResult.data;
+        team.rejectedDisplayingTasks = teamTasksResult.data;
+        team.loadingRejectedTasks = false;
+      });
+    });
+  }
 
-    onParticipantSelected() {
-      this.assigningTask.isUpdating = true;
-
-      const request: AssignParticipantToTaskRequest = {
-        electionId: this.assigningTask.electionId,
-        taskAssignmentId: this.assigningTask.id,
-        participantId: this.form.value.selectedParticipantIds[0],
-        taskTypeId: this.assigningTask.taskTypeId
-      };
-
-      this.subs.sink = this.workLocationTasksHttpService.assignParticipantToTask(request).subscribe((res) => {
-        if (res.isSuccess) {
-          this.loading = true;  
-          this.workLocationTasksHttpService.getTeamTasks(this.dailyTeamTasks[this.selectedTeamIndex].teamId, this.itemId, this.election.id, false).subscribe((teamTasksResult) => { 
-            this.dailyTeamTasks[this.selectedTeamIndex].tasks = teamTasksResult.data;
-            this.dailyTeamTasks[this.selectedTeamIndex].displayingTasks = teamTasksResult.data;
-          });
-          
-          this.subs.sink = this.workLocationTasksHttpService.getWorkLocationTasksSummary(this.itemId, this.election.id).subscribe((taskTypesSummaryResult) => {               
-            this.workLocationTasksSummary = taskTypesSummaryResult.data;
-            this.buildWorkLocationTasksSummary();
-          });
-
-          this.assigningTask.isUpdating = false;
-        } else {
-          this.assigningTask.isUpdating = false;
-        }
+  onDateChanged() {
+    if (this.selectedDateIndex >= 0) {
+      this.dailyTeamTasks.forEach((team) => {
+        team.displayingTasks = team.tasks.filter(t => (new Date(t.taskDate)).valueOf() === this.dailyWorkLocationTasks[this.selectedDateIndex].tasksDate.valueOf());
+        team.rejectedDisplayingTasks = team.rejectedTasks.filter(t => (new Date(t.taskDate)).valueOf() === this.dailyWorkLocationTasks[this.selectedDateIndex].tasksDate.valueOf());
       });
     }
-
-    copyTaskLink(taskDetailsPageUrl: string) {
-      this.clipboard.copy(taskDetailsPageUrl);
-      this.notificationService.showSuccess(this.translocoService.translate('tasks.success.task_link_copied'));
+    else {
+      this.dailyTeamTasks.forEach((team) => {
+        team.displayingTasks = team.tasks;
+        team.rejectedDisplayingTasks = team.rejectedTasks;
+      });
     }
+  }
 
-    removeParticipant(task: UpdatingTaskAssignment, teamIndex) {
-      this.selectedTeamIndex = teamIndex;
-      this.subs.sink = this.subs.sink = this.dialog
+  getTeamAssignedTasksCount(taskInfo) {
+    return taskInfo.taskTypes.map(t => t.assignedTasksCount).reduce((acc, value) => acc + value, 0);
+  }
+
+  getTeamAllTasksCount(taskInfo) {
+    return taskInfo.taskTypes.map(t => t.allTasksCount).reduce((acc, value) => acc + value, 0);
+  }
+
+  getTaskTypeAssignedTasksCount(taskType) {
+    const dailyWorkLocationTask = this.selectedDateIndex > - 1 ? this.dailyWorkLocationTasks[this.selectedDateIndex] : this.allDatesWorkLocationTasks;
+    let assignedTasksCount = 0;
+    dailyWorkLocationTask.teams.forEach((team) => {
+      const foundTaskTypes = team.taskTypes.filter(t => t.taskTypeId == taskType.id);
+      if (foundTaskTypes && foundTaskTypes.length > 0) {
+        assignedTasksCount += foundTaskTypes[0].assignedTasksCount;
+      }
+    })
+    return assignedTasksCount;
+  }
+
+  getTaskTypeAllTasksCount(taskType) {
+    const dailyWorkLocationTask = this.selectedDateIndex > - 1 ? this.dailyWorkLocationTasks[this.selectedDateIndex] : this.allDatesWorkLocationTasks;
+    let allTasksCount = 0;
+    dailyWorkLocationTask.teams.forEach((team) => {
+      const foundTaskTypes = team.taskTypes.filter(t => t.taskTypeId == taskType.id);
+      if (foundTaskTypes && foundTaskTypes.length > 0) {
+        allTasksCount += foundTaskTypes[0].allTasksCount;
+      }
+    })
+    return allTasksCount;
+  }
+
+  getSumAssignedTasksCount() {
+    const dailyWorkLocationTask = this.selectedDateIndex > - 1 ? this.dailyWorkLocationTasks[this.selectedDateIndex] : this.allDatesWorkLocationTasks;
+    let assignedTasksCount = 0;
+    dailyWorkLocationTask.teams.forEach((team) => {
+      team.taskTypes.forEach((taskType) => {
+        assignedTasksCount += taskType.assignedTasksCount;
+      })
+    })
+    return assignedTasksCount;
+  }
+
+  getSumAllTasksCount() {
+    const dailyWorkLocationTask = this.selectedDateIndex > - 1 ? this.dailyWorkLocationTasks[this.selectedDateIndex] : this.allDatesWorkLocationTasks;
+    let allTasksCount = 0;
+    dailyWorkLocationTask.teams.forEach((team) => {
+      team.taskTypes.forEach((taskType) => {
+        allTasksCount += taskType.allTasksCount;
+      })
+    })
+    return allTasksCount;
+  }
+
+  openDistributeTasks() {
+    this.router.navigate([RoutingNodes.TasksOnWorkLocation, this.itemId, RoutingNodes.Link_Distribute]);
+  }
+
+  openParticipantEditing(participantId: string) {
+    this.router.navigate([RoutingNodes.Participant, RoutingNodes.Link_Edit, participantId]);
+  }
+
+  openParticipantCreating(taskId: string) {
+    this.router.navigate([RoutingNodes.Participant, RoutingNodes.Link_Create, this.itemId, taskId]);
+  }
+
+  openReplyForParticipant(taskId: string) {
+    this.router.navigate([RoutingNodes.TasksOnWorkLocation, this.itemId, RoutingNodes.ReplyForParticipant, taskId]);
+  }
+
+  openAssignParticipantDialog(task: UpdatingTaskAssignment, teamIndex: number) {
+    this.assigningTask = task;
+    this.selectedTeamIndex = teamIndex;
+    this.form.value.selectedParticipantIds = [];
+    this.openAddParticipant = true;
+  }
+
+  onParticipantPickerClose() {
+    this.openAddParticipant = false;
+  }
+
+  onParticipantSelected() {
+    this.assigningTask.isUpdating = true;
+
+    const request: AssignParticipantToTaskRequest = {
+      electionId: this.assigningTask.electionId,
+      taskAssignmentId: this.assigningTask.id,
+      participantId: this.form.value.selectedParticipantIds[0],
+      taskTypeId: this.assigningTask.taskTypeId
+    };
+
+    this.subs.sink = this.workLocationTasksHttpService.assignParticipantToTask(request).subscribe((res) => {
+      if (res.isSuccess) {
+        this.loading = true;
+        this.workLocationTasksHttpService.getTeamTasks(this.dailyTeamTasks[this.selectedTeamIndex].teamId, this.itemId, this.election.id, false).subscribe((teamTasksResult) => {
+          this.dailyTeamTasks[this.selectedTeamIndex].tasks = teamTasksResult.data;
+          this.dailyTeamTasks[this.selectedTeamIndex].displayingTasks = teamTasksResult.data;
+        });
+
+        this.subs.sink = this.workLocationTasksHttpService.getWorkLocationTasksSummary(this.itemId, this.election.id).subscribe((taskTypesSummaryResult) => {
+          this.workLocationTasksSummary = taskTypesSummaryResult.data;
+          this.buildWorkLocationTasksSummary();
+        });
+
+        this.assigningTask.isUpdating = false;
+      } else {
+        this.assigningTask.isUpdating = false;
+      }
+    });
+  }
+
+  copyTaskLink(taskDetailsPageUrl: string) {
+    this.clipboard.copy(taskDetailsPageUrl);
+    this.notificationService.showSuccess(this.translocoService.translate('tasks.success.task_link_copied'));
+  }
+
+  removeParticipant(task: UpdatingTaskAssignment, teamIndex) {
+    this.selectedTeamIndex = teamIndex;
+    this.subs.sink = this.subs.sink = this.dialog
       .open(ConfirmationDialogComponent, {
         minWidth: 400,
         data: {
@@ -385,16 +392,16 @@ export class WorkLocationTasksOverviewComponent implements OnInit {
             taskAssignmentId: task.id
           };
 
-          this.subs.sink = this.workLocationTasksHttpService.removeParticipantFromTask(request).subscribe((res) => {            
+          this.subs.sink = this.workLocationTasksHttpService.removeParticipantFromTask(request).subscribe((res) => {
             if (res.isSuccess) {
               this.loading = true;
 
-              this.workLocationTasksHttpService.getTeamTasks(this.dailyTeamTasks[this.selectedTeamIndex].teamId, this.itemId, this.election.id, false).subscribe((teamTasksResult) => { 
+              this.workLocationTasksHttpService.getTeamTasks(this.dailyTeamTasks[this.selectedTeamIndex].teamId, this.itemId, this.election.id, false).subscribe((teamTasksResult) => {
                 this.dailyTeamTasks[this.selectedTeamIndex].tasks = teamTasksResult.data;
                 this.dailyTeamTasks[this.selectedTeamIndex].displayingTasks = teamTasksResult.data;
               });
 
-              this.subs.sink = this.workLocationTasksHttpService.getWorkLocationTasksSummary(this.itemId, this.election.id).subscribe((taskTypesSummaryResult) => {               
+              this.subs.sink = this.workLocationTasksHttpService.getWorkLocationTasksSummary(this.itemId, this.election.id).subscribe((taskTypesSummaryResult) => {
                 this.workLocationTasksSummary = taskTypesSummaryResult.data;
                 this.buildWorkLocationTasksSummary();
               });
@@ -406,5 +413,42 @@ export class WorkLocationTasksOverviewComponent implements OnInit {
           });
         }
       });
-    }
+  }
+  moveVacantTasksToOtherTeam(currentTeamId: string, teamIndex: number) {
+    const tasksIds = this.dailyTeamTasks[teamIndex].tasks
+      .filter(t => t.teamId == currentTeamId && t.participantId == null)
+      .map(t => t.id);
+
+    const request: MoveTasksRequest = {
+      taskIds: tasksIds,
+      targetTeamId: this.selectedTeam as unknown as string,
+      sourceTeamId: currentTeamId
+    };
+    this.workLocationTasksHttpService.moveTasks(request).subscribe((res) => {
+
+      if (res.isSuccess) {
+        this.notificationService.showSuccess(this.translocoService.translate('tasks.success.tasks_moved'));
+      } else {
+        this.notificationService.showSuccess(this.translocoService.translate('tasks.error.tasks_moved'));
+      }
+
+      this.workLocationTasksHttpService.getTeamTasks(this.dailyTeamTasks[teamIndex].teamId, this.itemId, this.election.id, false).subscribe((teamTasksResult) => {
+        this.dailyTeamTasks[teamIndex].tasks = teamTasksResult.data;
+        this.dailyTeamTasks[teamIndex].displayingTasks = teamTasksResult.data;
+      });
+      this.subs.sink = this.workLocationTasksHttpService.getWorkLocationTasksSummary(this.itemId, this.election.id).subscribe((taskTypesSummaryResult) => {
+        this.workLocationTasksSummary = taskTypesSummaryResult.data;
+        this.buildWorkLocationTasksSummary();
+        this.buildTeamTasksSummary();
+        this.buildRejectedTeamTasksSummary();
+      });
+      this.dailyTeamTasks[teamIndex].loadingTasks = false;
+
+    });
+  }
+
+  onTeamChanged() {
+    this.targetTeamId = this.selectedTeam;
+  }
 }
+

--- a/Valghalla.Internal.Web/src/features/tasks/components/work-location-tasks-overview/work-location-tasks-overview.component.ts
+++ b/Valghalla.Internal.Web/src/features/tasks/components/work-location-tasks-overview/work-location-tasks-overview.component.ts
@@ -426,12 +426,6 @@ export class WorkLocationTasksOverviewComponent implements OnInit {
     };
     this.workLocationTasksHttpService.moveTasks(request).subscribe((res) => {
 
-      if (res.isSuccess) {
-        this.notificationService.showSuccess(this.translocoService.translate('tasks.success.tasks_moved'));
-      } else {
-        this.notificationService.showSuccess(this.translocoService.translate('tasks.error.tasks_moved'));
-      }
-
       this.workLocationTasksHttpService.getTeamTasks(this.dailyTeamTasks[teamIndex].teamId, this.itemId, this.election.id, false).subscribe((teamTasksResult) => {
         this.dailyTeamTasks[teamIndex].tasks = teamTasksResult.data;
         this.dailyTeamTasks[teamIndex].displayingTasks = teamTasksResult.data;

--- a/Valghalla.Internal.Web/src/features/tasks/models/move-tasks-request.ts
+++ b/Valghalla.Internal.Web/src/features/tasks/models/move-tasks-request.ts
@@ -1,0 +1,5 @@
+export interface MoveTasksRequest {
+taskIds: string[];
+targetTeamId: string;
+sourceTeamId: string;
+}

--- a/Valghalla.Internal.Web/src/features/tasks/services/work-location-tasks-http.service.ts
+++ b/Valghalla.Internal.Web/src/features/tasks/services/work-location-tasks-http.service.ts
@@ -12,6 +12,8 @@ import { AssignParticipantToTaskRequest } from '../models/assign-participant-to-
 import { RemoveParticipantFromTaskRequest } from '../models/remove-participant-from-task-request';
 import { ReplyForParticipantRequest } from '../models/reply-for-participant-request';
 import { WorkLocationTasksDistributingRequest } from '../models/work-location-tasks-distributing-request';
+import { TeamShared } from 'src/shared/models/team/team-shared';
+import { MoveTasksRequest } from '../models/move-tasks-request';
 
 @Injectable()
 export class WorkLocationTasksHttpService {
@@ -21,14 +23,14 @@ export class WorkLocationTasksHttpService {
     private readonly httpClient: HttpClient,
     private readonly translocoService: TranslocoService,
     private readonly notificationService: NotificationService,
-  ) {}
+  ) { }
 
   getWorkLocation(workLocationId: string, electionId: string): Observable<Response<WorkLocationInfo>> {
     return this.httpClient
       .get<Response<WorkLocationInfo>>(getBaseApiUrl() + 'shared/worklocation/getworklocation', {
         params: {
-            workLocationId: workLocationId,
-            electionId: electionId
+          workLocationId: workLocationId,
+          electionId: electionId
         },
       })
       .pipe(
@@ -45,8 +47,8 @@ export class WorkLocationTasksHttpService {
     return this.httpClient
       .get<Response<WorkLocationTasksSummary>>(this.baseUrl + 'getworklocationtaskssummary', {
         params: {
-            workLocationId: workLocationId,
-            electionId: electionId
+          workLocationId: workLocationId,
+          electionId: electionId
         },
       })
       .pipe(
@@ -160,6 +162,22 @@ export class WorkLocationTasksHttpService {
         if (res.isSuccess) {
           const msg = this.translocoService.translate('tasks.success.reply_for_participant');
           this.notificationService.showSuccess(msg);
+        }
+      }),
+    );
+  }
+  moveTasks(request: MoveTasksRequest): Observable<Response<void>> {
+    return this.httpClient.post<Response<void>>(this.baseUrl + 'movetasks', request).pipe(
+      catchError((err) => {
+        // const msg = this.translocoService.translate('tasks.error.reply_for_participant');
+        // this.notificationService.showError(msg);
+
+        return throwError(() => err);
+      }),
+      tap((res) => {
+        if (res.isSuccess) {
+          // const msg = this.translocoService.translate('tasks.success.reply_for_participant');
+          // this.notificationService.showSuccess(msg);
         }
       }),
     );

--- a/Valghalla.Internal.Web/src/features/tasks/services/work-location-tasks-http.service.ts
+++ b/Valghalla.Internal.Web/src/features/tasks/services/work-location-tasks-http.service.ts
@@ -169,15 +169,12 @@ export class WorkLocationTasksHttpService {
   moveTasks(request: MoveTasksRequest): Observable<Response<void>> {
     return this.httpClient.post<Response<void>>(this.baseUrl + 'movetasks', request).pipe(
       catchError((err) => {
-        // const msg = this.translocoService.translate('tasks.error.reply_for_participant');
-        // this.notificationService.showError(msg);
-
+        this.notificationService.showSuccess(this.translocoService.translate('tasks.error.tasks_moved'));
         return throwError(() => err);
       }),
       tap((res) => {
         if (res.isSuccess) {
-          // const msg = this.translocoService.translate('tasks.success.reply_for_participant');
-          // this.notificationService.showSuccess(msg);
+          this.notificationService.showSuccess(this.translocoService.translate('tasks.success.tasks_moved'));          
         }
       }),
     );


### PR DESCRIPTION
As administrator, I need to be able to move vacant tasks from one team to another across all work locations, so I quickly can make them available for interested participants on another team.

Use case

When a political party can’t find any more participants, I want to make the vacant tasks available for another team that have more participants available.