### PR TITLE
Fejl 2

### DIFF
--- a/Valghalla.Application/Communication/ICommunicationHelper.cs
+++ b/Valghalla.Application/Communication/ICommunicationHelper.cs
@@ -8,6 +8,7 @@
         Task<bool> ValidateRemovedFromTaskByValidationAsync(Guid participantId, Guid taskAssignmentId, CancellationToken cancellationToken);
         Task<bool> ValidateTaskInvitationReminderAsync(Guid participantId, Guid taskAssignmentId, CancellationToken cancellationToken);
         Task<bool> ValidateTaskReminderAsync(Guid participantId, Guid taskAssignmentId, CancellationToken cancellationToken);
+        Task<bool> ValidateTaskReminderParticipantAsync(Guid participantId,int templateType, CancellationToken cancellationToken);
         Task<bool> ValidateTaskRegistrationAsync(Guid participantId, Guid taskAssignmentId, CancellationToken cancellationToken);
         Task<bool> ValidateTaskInvitationRetractedAsync(Guid taskAssignmentId, CancellationToken cancellationToken);
     }

--- a/Valghalla.Application/Communication/ICommunicationQueryRepository.cs
+++ b/Valghalla.Application/Communication/ICommunicationQueryRepository.cs
@@ -14,5 +14,6 @@
         Task<CommunicationTemplate?> GetTaskReminderCommunicationTemplateAsync(Guid taskAssignmentId, CancellationToken cancellationToken);
         Task<CommunicationTemplate?> GetTaskRetractedInvitationCommunicationTemplateAsync(Guid taskAssignmentId, CancellationToken cancellationToken);
         Task<CommunicationTemplate?> GetCommunicationTemplateAsync(Guid templateId, CancellationToken cancellationToken);
+        Task<CommunicationParticipantInfo> GetParticipantAsync(Guid participantId, CancellationToken cancellationToken);
     }
 }

--- a/Valghalla.Infrastructure/Communication/CommunicationQueryRepository.cs
+++ b/Valghalla.Infrastructure/Communication/CommunicationQueryRepository.cs
@@ -1,5 +1,7 @@
 ﻿using AutoMapper;
+
 using Microsoft.EntityFrameworkCore;
+
 using Valghalla.Application.Communication;
 using Valghalla.Database;
 using Valghalla.Database.Entities.Tables;
@@ -183,6 +185,25 @@ namespace Valghalla.Infrastructure.Communication
                 .SingleOrDefaultAsync(cancellationToken);
 
             return mapper.Map<CommunicationTemplate>(communicationTemplate);
+        }
+        public async Task<CommunicationParticipantInfo> GetParticipantAsync(Guid participantId, CancellationToken cancellationToken)
+        {
+            var query = await participants
+                .Where(i => i.Id == participantId)
+                .Select(i => new { i.Id, i.FirstName, i.LastName, i.MobileNumber, i.Email, i.Cpr, i.ExemptDigitalPost })
+                .SingleOrDefaultAsync(cancellationToken);
+
+            if (query == null) return null!;
+            return new CommunicationParticipantInfo
+            {
+                Id = query.Id,
+                Name = query.FirstName + " " + query.LastName,
+                MobileNumber = query.MobileNumber,
+                Email = query.Email,
+                Cpr = query.Cpr,
+                ExemptDigitalPost = query.ExemptDigitalPost
+            };
+
         }
 
         private async Task<string> GetMunicipalityNameAsync(CancellationToken cancellationToken)

--- a/Valghalla.Integration/Communication/CommunicationHelper.cs
+++ b/Valghalla.Integration/Communication/CommunicationHelper.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Security.Policy;
-using Valghalla.Application.Communication;
+﻿using Valghalla.Application.Communication;
 using Valghalla.Application.Tenant;
 
 namespace Valghalla.Integration.Communication
@@ -136,6 +134,17 @@ namespace Valghalla.Integration.Communication
             return true;
         }
 
+        public async Task<bool> ValidateTaskReminderParticipantAsync(Guid participantId, int templateType, CancellationToken cancellationToken)
+        {
+            var participant = await communicationQueryRepository.GetParticipantAsync(participantId, cancellationToken).ConfigureAwait(false);
+
+            if (templateType is TemplateType.DigitalPost && participant.ExemptDigitalPost is true) return false;
+            if (templateType is TemplateType.Email && participant.Email is null) return false;
+            if (templateType is TemplateType.SMS && participant.MobileNumber is null) return false;
+
+            return true;
+        }
+
         public async Task<bool> ValidateTaskRegistrationAsync(Guid participantId, Guid taskAssignmentId, CancellationToken cancellationToken)
         {
             var taskAssignment = await communicationQueryRepository.GetTaskAssignmentCommunicationInfoAsync(taskAssignmentId, cancellationToken)
@@ -194,7 +203,7 @@ namespace Valghalla.Integration.Communication
                 contactLinkHTML = "<a href=\"" + contactLink + "\">" + contactLink + "</a>";
                 invitationLinkHTML = "<a href=\"" + invitationLink + "\">" + invitationLink + "</a>";
             }
-            
+
             return template
                 .Replace("!name", info.Participant.Name)
                 .Replace("!election", info.ElectionTitle)

--- a/Valghalla.Internal.Application.Tests/Valghalla.Internal.Application.Tests.csproj
+++ b/Valghalla.Internal.Application.Tests/Valghalla.Internal.Application.Tests.csproj
@@ -7,7 +7,6 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />

--- a/Valghalla.Internal.Infrastructure.Tests/CommunicationHelperTests.cs
+++ b/Valghalla.Internal.Infrastructure.Tests/CommunicationHelperTests.cs
@@ -1,0 +1,101 @@
+﻿using NSubstitute;
+
+using Valghalla.Application.Communication;
+using Valghalla.Application.Tenant;
+using Valghalla.Integration.Communication;
+
+namespace Valghalla.Internal.Infrastructure.Tests;
+
+[TestClass]
+public class CommunicationHelperTests
+{
+    //private ICommunicationQueryRepository mockQueryRepo;
+    //private ITenantContextProvider mockTenantContext;
+    //private CommunicationHelper helper; // Change access modifier to public for testing
+    //private readonly Guid participantId = Guid.Parse("e0d55398-56e5-4abe-bc71-dcc386f23f77");
+    //private readonly CancellationToken token = CancellationToken.None;
+
+    //[TestInitialize]
+    //public void Setup()
+    //{
+    //    mockQueryRepo = Substitute.For<ICommunicationQueryRepository>();
+    //    mockTenantContext = Substitute.For<ITenantContextProvider>();
+    //    helper = new CommunicationHelper(mockTenantContext, mockQueryRepo);
+    //}
+
+    //[TestMethod]
+    //public async Task ValidateTaskReminderParticipantAsync_ReturnsFalse_WhenDigitalPostAndExempt()
+    //{
+    //    // Arrange
+    //    var participant = new CommunicationParticipantInfo
+    //    {
+    //        Id = Guid.Parse("e0d55398-56e5-4abe-bc71-dcc386f23f77"),
+    //        ExemptDigitalPost = true,
+    //        Email = "test@example.com",
+    //        MobileNumber = "12345678"
+    //    };
+
+    //    mockQueryRepo.GetParticipantAsync(participantId, token)
+    //                 .Returns(participant);
+
+    //    // Act
+    //    var result = await helper.ValidateTaskReminderParticipantAsync(participantId, TemplateType.DigitalPost, token);
+
+    //    // Assert
+    //    Assert.IsFalse(result);
+    //}
+
+    //[TestMethod]
+    //public async Task ValidateTaskReminderParticipantAsync_ReturnsFalse_WhenEmailAndMissingEmail()
+    //{
+    //    var participant = new CommunicationParticipantInfo
+    //    {
+    //        ExemptDigitalPost = false,
+    //        Email = null,
+    //        MobileNumber = "12345678"
+    //    };
+
+    //    mockQueryRepo.GetParticipantAsync(participantId, token)
+    //                 .Returns(participant);
+
+    //    var result = await helper.ValidateTaskReminderParticipantAsync(participantId, TemplateType.Email, token);
+
+    //    Assert.IsFalse(result);
+    //}
+
+    //[TestMethod]
+    //public async Task ValidateTaskReminderParticipantAsync_ReturnsFalse_WhenSmsAndMissingMobile()
+    //{
+    //    var participant = new CommunicationParticipantInfo
+    //    {
+    //        ExemptDigitalPost = false,
+    //        Email = "test@example.com",
+    //        MobileNumber = null
+    //    };
+
+    //    mockQueryRepo.GetParticipantAsync(participantId, token)
+    //                 .Returns(participant);
+
+    //    var result = await helper.ValidateTaskReminderParticipantAsync(participantId, TemplateType.SMS, token);
+
+    //    Assert.IsFalse(result);
+    //}
+
+    //[TestMethod]
+    //public async Task ValidateTaskReminderParticipantAsync_ReturnsTrue_WhenAllValidForEmail()
+    //{
+    //    var participant = new CommunicationParticipantInfo
+    //    {
+    //        ExemptDigitalPost = false,
+    //        Email = "test@example.com",
+    //        MobileNumber = "12345678"
+    //    };
+
+    //    mockQueryRepo.GetParticipantAsync(participantId, token)
+    //                 .Returns(participant);
+
+    //    var result = await helper.ValidateTaskReminderParticipantAsync(participantId, TemplateType.Email, token);
+
+    //    Assert.IsTrue(result);
+    //}
+}

--- a/Valghalla.Internal.Infrastructure.Tests/Valghalla.Internal.Infrastructure.Tests.csproj
+++ b/Valghalla.Internal.Infrastructure.Tests/Valghalla.Internal.Infrastructure.Tests.csproj
@@ -8,14 +8,15 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.0" />
     <PackageReference Include="coverlet.collector" Version="3.2.0" />
-    <PackageReference Include="NSubstitute" Version="5.0.0" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Valghalla.Internal.Infrastructure\Valghalla.Internal.Infrastructure.csproj" />
+    <ProjectReference Include="..\Valghalla.Worker\Valghalla.Worker.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Description: 
The automatic sending of reminders stops if the system encounters a participant who does not have a registered mobile number or email address, or if a participant is not enrolled in Digital Post. 

Workaround: 
Send the reminder manually → this is by no means ideal, as there are often many recipients of a reminder. 

As a system administrator 
I want to ensure that the automatic sending of reminders does not stop if a participant has not provided a phone number and/or email address or is not registered for Digital Post 
So that the system skips these participants and continues sending the reminder to the remaining participants 

Acceptance Criteria 
Given that a participant has not registered a mobile number, email address or is not registered for Digital Post 

When the system attempts to send a reminder 

Then ensure that: 
• The participant is skipped
• The sending continues to the remaining participants with valid information 
• The system logs which participants did not receive the reminder 
o Including the reason why the reminder was not sent
